### PR TITLE
Fix untar timeout issue and then some

### DIFF
--- a/jwala-common/src/main/java/com/cerner/jwala/commandprocessor/impl/jsch/JschCommandProcessorImpl.java
+++ b/jwala-common/src/main/java/com/cerner/jwala/commandprocessor/impl/jsch/JschCommandProcessorImpl.java
@@ -5,19 +5,20 @@ import com.cerner.jwala.common.exec.ExecReturnCode;
 import com.cerner.jwala.common.exec.RemoteExecCommand;
 import com.cerner.jwala.common.jsch.JschService;
 import com.cerner.jwala.common.jsch.RemoteCommandReturnInfo;
+import com.cerner.jwala.common.properties.ApplicationProperties;
 import com.cerner.jwala.exception.RemoteCommandFailureException;
 
 import java.io.IOException;
 
 public class JschCommandProcessorImpl implements CommandProcessor {
 
+    private static final String JSCH_SHELL_READ_REMOTE_OUTPUT_TIMEOUT = "jsch.shell.read.remote.output.timeout";
+    private static final String JSCH_EXEC_READ_REMOTE_OUTPUT_TIMEOUT = "jsch.exec.read.remote.output.timeout";
+    private static final String DEFAULT_READ_REMOTE_OUTPUT_TIMEOUT = "180000";
+
     private final JschService jschService;
     private final RemoteExecCommand remoteExecCommand;
-
     private ExecReturnCode returnCode;
-
-    private static final int SHELL_REMOTE_OUTPUT_READ_WAIT_TIME = 180000;
-    private static final int EXEC_REMOTE_OUTPUT_READ_WAIT_TIME = 5000;
     private String commandOutputStr;
     private String errorOutputStr;
 
@@ -36,11 +37,15 @@ public class JschCommandProcessorImpl implements CommandProcessor {
     public void processCommand() throws RemoteCommandFailureException {
         final RemoteCommandReturnInfo remoteCommandReturnInfo;
         if (remoteExecCommand.getCommand().getRunInShell()) {
+            final int shellReadRemoteOutputTimeout =
+                    Integer.parseInt(ApplicationProperties.get(JSCH_SHELL_READ_REMOTE_OUTPUT_TIMEOUT, DEFAULT_READ_REMOTE_OUTPUT_TIMEOUT));
             remoteCommandReturnInfo = jschService.runShellCommand(remoteExecCommand.getRemoteSystemConnection(),
-                    remoteExecCommand.getCommand().toCommandString(), SHELL_REMOTE_OUTPUT_READ_WAIT_TIME);
+                    remoteExecCommand.getCommand().toCommandString(), shellReadRemoteOutputTimeout);
         } else {
+            final int execReadRemoteOutputTimeout =
+                    Integer.parseInt(ApplicationProperties.get(JSCH_EXEC_READ_REMOTE_OUTPUT_TIMEOUT, DEFAULT_READ_REMOTE_OUTPUT_TIMEOUT));
             remoteCommandReturnInfo = jschService.runExecCommand(remoteExecCommand.getRemoteSystemConnection(),
-                    remoteExecCommand.getCommand().toCommandString(), EXEC_REMOTE_OUTPUT_READ_WAIT_TIME);
+                    remoteExecCommand.getCommand().toCommandString(), execReadRemoteOutputTimeout);
 
         }
 

--- a/jwala-common/src/main/java/com/cerner/jwala/commandprocessor/impl/jsch/JschCommandProcessorImpl.java
+++ b/jwala-common/src/main/java/com/cerner/jwala/commandprocessor/impl/jsch/JschCommandProcessorImpl.java
@@ -1,5 +1,7 @@
 package com.cerner.jwala.commandprocessor.impl.jsch;
 
+import static com.cerner.jwala.common.properties.PropertyKeys.*;
+
 import com.cerner.jwala.commandprocessor.CommandProcessor;
 import com.cerner.jwala.common.exec.ExecReturnCode;
 import com.cerner.jwala.common.exec.RemoteExecCommand;
@@ -12,8 +14,6 @@ import java.io.IOException;
 
 public class JschCommandProcessorImpl implements CommandProcessor {
 
-    private static final String JSCH_SHELL_READ_REMOTE_OUTPUT_TIMEOUT = "jsch.shell.read.remote.output.timeout";
-    private static final String JSCH_EXEC_READ_REMOTE_OUTPUT_TIMEOUT = "jsch.exec.read.remote.output.timeout";
     private static final String DEFAULT_READ_REMOTE_OUTPUT_TIMEOUT = "180000";
 
     private final JschService jschService;
@@ -38,12 +38,14 @@ public class JschCommandProcessorImpl implements CommandProcessor {
         final RemoteCommandReturnInfo remoteCommandReturnInfo;
         if (remoteExecCommand.getCommand().getRunInShell()) {
             final int shellReadRemoteOutputTimeout =
-                    Integer.parseInt(ApplicationProperties.get(JSCH_SHELL_READ_REMOTE_OUTPUT_TIMEOUT, DEFAULT_READ_REMOTE_OUTPUT_TIMEOUT));
+                    Integer.parseInt(ApplicationProperties.get(JSCH_SHELL_READ_REMOTE_OUTPUT_TIMEOUT.getPropertyName(),
+                                                               DEFAULT_READ_REMOTE_OUTPUT_TIMEOUT));
             remoteCommandReturnInfo = jschService.runShellCommand(remoteExecCommand.getRemoteSystemConnection(),
                     remoteExecCommand.getCommand().toCommandString(), shellReadRemoteOutputTimeout);
         } else {
             final int execReadRemoteOutputTimeout =
-                    Integer.parseInt(ApplicationProperties.get(JSCH_EXEC_READ_REMOTE_OUTPUT_TIMEOUT, DEFAULT_READ_REMOTE_OUTPUT_TIMEOUT));
+                    Integer.parseInt(ApplicationProperties.get(JSCH_EXEC_READ_REMOTE_OUTPUT_TIMEOUT.getPropertyName(),
+                                                               DEFAULT_READ_REMOTE_OUTPUT_TIMEOUT));
             remoteCommandReturnInfo = jschService.runExecCommand(remoteExecCommand.getRemoteSystemConnection(),
                     remoteExecCommand.getCommand().toCommandString(), execReadRemoteOutputTimeout);
 

--- a/jwala-common/src/main/java/com/cerner/jwala/common/jsch/impl/JschServiceImpl.java
+++ b/jwala-common/src/main/java/com/cerner/jwala/common/jsch/impl/JschServiceImpl.java
@@ -1,5 +1,7 @@
 package com.cerner.jwala.common.jsch.impl;
 
+import static com.cerner.jwala.common.properties.PropertyKeys.*;
+
 import java.io.BufferedInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -48,9 +50,7 @@ public class JschServiceImpl implements JschService {
     private static final String EXIT_CODE_END_MARKER = "***";
     private static final int BYTE_CHUNK_SIZE = 1024;
     private static final int CHANNEL_EXEC_CLOSE_TIMEOUT = 300000;
-    private static final String JSCH_CHANNEL_SHELL_READ_INPUT_SLEEP_DURATION = "jsch.channel.shell.read.input.sleep.duration";
     private static final String SHELL_READ_SLEEP_DEFAULT_VALUE = "250";
-    private static final String JSCH_EXEC_READ_REMOTE_OUTPUT_LOOP_SLEEP_TIME = "jsch.exec.read.remote.output.loop.sleep.time";
     private static final String READ_LOOP_SLEEP_TIME_DEFAULT_VALUE = "100";
 
     @Autowired
@@ -200,8 +200,8 @@ public class JschServiceImpl implements JschService {
 
         final byte[] tmp = new byte[BYTE_CHUNK_SIZE];
         final long startTime = System.currentTimeMillis();
-        final long readLoopSleepTime = Long.parseLong(ApplicationProperties.get(JSCH_EXEC_READ_REMOTE_OUTPUT_LOOP_SLEEP_TIME,
-                                                                                READ_LOOP_SLEEP_TIME_DEFAULT_VALUE));
+        final long readLoopSleepTime = Long.parseLong(ApplicationProperties.get(
+                JSCH_EXEC_READ_REMOTE_OUTPUT_LOOP_SLEEP_TIME.getPropertyName(), READ_LOOP_SLEEP_TIME_DEFAULT_VALUE));
 
         while (true) {
             // read the stream
@@ -268,8 +268,8 @@ public class JschServiceImpl implements JschService {
             throw new JschServiceException("Expecting non-null end marker when reading remote output");
         }
 
-        final int readInputSleepDuration = Integer.parseInt(ApplicationProperties.get(JSCH_CHANNEL_SHELL_READ_INPUT_SLEEP_DURATION,
-                SHELL_READ_SLEEP_DEFAULT_VALUE));
+        final int readInputSleepDuration = Integer.parseInt(ApplicationProperties.get(
+                JSCH_CHANNEL_SHELL_READ_INPUT_SLEEP_DURATION.getPropertyName(), SHELL_READ_SLEEP_DEFAULT_VALUE));
         final BufferedInputStream buffIn = new BufferedInputStream(remoteOutput);
         final byte[] bytes = new byte[BYTE_CHUNK_SIZE];
         final ByteArrayOutputStream out = new ByteArrayOutputStream();

--- a/jwala-common/src/main/java/com/cerner/jwala/common/jsch/impl/JschServiceImpl.java
+++ b/jwala-common/src/main/java/com/cerner/jwala/common/jsch/impl/JschServiceImpl.java
@@ -93,11 +93,12 @@ public class JschServiceImpl implements JschService {
     }
 
     /**
-     * Reads data from inputstream which is wrapped inside {@link RemoteCommandReturnInfo}
+     * Reads remote output which is then wrapped inside {@link RemoteCommandReturnInfo}
      *
      * @param command the command to run
      * @param in the input stream
      * @param timeout the length of time in ms in which the method waits for a available byte(s) as a result of command  @return result of the command
+     * @return {@link RemoteCommandReturnInfo}
      * @throws IOException
      */
     private RemoteCommandReturnInfo getShellRemoteCommandReturnInfo(final String command, final InputStream in, final long timeout)
@@ -150,12 +151,11 @@ public class JschServiceImpl implements JschService {
     }
 
     /**
-     * Runs a command via jsch's exec channel.
-     * Unlike the shell channel, an exec channel closes after an execution of a command.
+     * Reads std and error remote output which are then wrapped inside {@link RemoteCommandReturnInfo}
      *
      * @param channelExec the channel where the command is sent for execution
-     * @param timeout     the length of time in ms in which the method waits for a available byte(s) as a result of command
-     * @return result of the command
+     * @param timeout the length of time in ms in which the method waits for a available byte(s) as a result of command
+     * @return {@link RemoteCommandReturnInfo}
      */
     private RemoteCommandReturnInfo getExecRemoteCommandReturnInfo(final ChannelExec channelExec, final long timeout)
             throws IOException, JSchException {

--- a/jwala-common/src/main/java/com/cerner/jwala/common/properties/ApplicationProperties.java
+++ b/jwala-common/src/main/java/com/cerner/jwala/common/properties/ApplicationProperties.java
@@ -99,7 +99,15 @@ public class ApplicationProperties {
     }
 
     private void init() {
-        String propertiesFile = System.getProperty(PROPERTIES_ROOT_PATH) + "/" + PROPERTIES_FILE_NAME;
+
+        String propertiesRootPath = System.getProperty(PROPERTIES_ROOT_PATH);
+        if (propertiesRootPath == null) {
+            propertiesRootPath = this.getClass().getClassLoader().getResource(PROPERTIES_FILE_NAME).getPath();
+            propertiesRootPath = propertiesRootPath.substring(0, propertiesRootPath.lastIndexOf('/'));
+            LOGGER.error("Properties root path not set! Loading default resource root path: {}", propertiesRootPath);
+        }
+
+        String propertiesFile = propertiesRootPath + "/" + PROPERTIES_FILE_NAME;
         Properties tempProperties = new Properties();
         try {
             tempProperties.load(new FileReader(new File(propertiesFile)));

--- a/jwala-common/src/main/java/com/cerner/jwala/common/properties/PropertyKeys.java
+++ b/jwala-common/src/main/java/com/cerner/jwala/common/properties/PropertyKeys.java
@@ -24,8 +24,11 @@ public enum PropertyKeys {
     LOCAL_JWALA_BINARY_DIR("jwala.binary.dir"),
     JMAP_DUMP_LIVE_ENABLED("jmap.dump.live.enabled"),
     TOMCAT_MANAGER_XML_SSL_PATH("tomcat.manager.xml.ssl.path"),
-    PATHS_RESOURCE_TEMPLATES("paths.resource-templates");
-
+    PATHS_RESOURCE_TEMPLATES("paths.resource-templates"),
+    JSCH_CHANNEL_SHELL_READ_INPUT_SLEEP_DURATION("jsch.channel.shell.read.input.sleep.duration"),
+    JSCH_EXEC_READ_REMOTE_OUTPUT_LOOP_SLEEP_TIME("jsch.exec.read.remote.output.loop.sleep.time"),
+    JSCH_SHELL_READ_REMOTE_OUTPUT_TIMEOUT("jsch.shell.read.remote.output.timeout"),
+    JSCH_EXEC_READ_REMOTE_OUTPUT_TIMEOUT("jsch.exec.read.remote.output.timeout");
 
     private String propertyName;
 

--- a/jwala-services/src/main/java/com/cerner/jwala/service/impl/spring/component/JschRemoteCommandExecutorServiceImpl.java
+++ b/jwala-services/src/main/java/com/cerner/jwala/service/impl/spring/component/JschRemoteCommandExecutorServiceImpl.java
@@ -3,6 +3,7 @@ package com.cerner.jwala.service.impl.spring.component;
 import com.cerner.jwala.common.exec.RemoteExecCommand;
 import com.cerner.jwala.common.jsch.JschService;
 import com.cerner.jwala.common.jsch.RemoteCommandReturnInfo;
+import com.cerner.jwala.common.properties.ApplicationProperties;
 import com.cerner.jwala.service.RemoteCommandExecutorService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -15,8 +16,9 @@ import org.springframework.stereotype.Service;
 @Service
 public class JschRemoteCommandExecutorServiceImpl implements RemoteCommandExecutorService {
 
-    private static final int SHELL_REMOTE_OUTPUT_READ_WAIT_TIME = 180000;
-    private static final int EXEC_REMOTE_OUTPUT_READ_WAIT_TIME = 3000;
+    private static final String JSCH_SHELL_READ_REMOTE_OUTPUT_TIMEOUT = "jsch.shell.read.remote.output.timeout";
+    private static final String JSCH_EXEC_READ_REMOTE_OUTPUT_TIMEOUT = "jsch.exec.read.remote.output.timeout";
+    private static final String DEFAULT_READ_REMOTE_OUTPUT_TIMEOUT = "180000";
 
     private final JschService jschService;
 
@@ -28,11 +30,15 @@ public class JschRemoteCommandExecutorServiceImpl implements RemoteCommandExecut
     @Override
     public RemoteCommandReturnInfo executeCommand(final RemoteExecCommand remoteExecCommand) {
         if (remoteExecCommand.getCommand().getRunInShell()) {
+            final int shellReadRemoteOutputTimeout =
+                    Integer.parseInt(ApplicationProperties.get(JSCH_SHELL_READ_REMOTE_OUTPUT_TIMEOUT, DEFAULT_READ_REMOTE_OUTPUT_TIMEOUT));
             return jschService.runShellCommand(remoteExecCommand.getRemoteSystemConnection(),
-                    remoteExecCommand.getCommand().toCommandString(), SHELL_REMOTE_OUTPUT_READ_WAIT_TIME);
+                    remoteExecCommand.getCommand().toCommandString(), shellReadRemoteOutputTimeout);
         }
+        final int execReadRemoteOutputTimeout =
+                Integer.parseInt(ApplicationProperties.get(JSCH_EXEC_READ_REMOTE_OUTPUT_TIMEOUT, DEFAULT_READ_REMOTE_OUTPUT_TIMEOUT));
         return jschService.runExecCommand(remoteExecCommand.getRemoteSystemConnection(),
-                remoteExecCommand.getCommand().toCommandString(), EXEC_REMOTE_OUTPUT_READ_WAIT_TIME);
+                remoteExecCommand.getCommand().toCommandString(), execReadRemoteOutputTimeout);
     }
 
 }

--- a/jwala-services/src/main/java/com/cerner/jwala/service/impl/spring/component/JschRemoteCommandExecutorServiceImpl.java
+++ b/jwala-services/src/main/java/com/cerner/jwala/service/impl/spring/component/JschRemoteCommandExecutorServiceImpl.java
@@ -1,5 +1,7 @@
 package com.cerner.jwala.service.impl.spring.component;
 
+import static com.cerner.jwala.common.properties.PropertyKeys.*;
+
 import com.cerner.jwala.common.exec.RemoteExecCommand;
 import com.cerner.jwala.common.jsch.JschService;
 import com.cerner.jwala.common.jsch.RemoteCommandReturnInfo;
@@ -16,8 +18,6 @@ import org.springframework.stereotype.Service;
 @Service
 public class JschRemoteCommandExecutorServiceImpl implements RemoteCommandExecutorService {
 
-    private static final String JSCH_SHELL_READ_REMOTE_OUTPUT_TIMEOUT = "jsch.shell.read.remote.output.timeout";
-    private static final String JSCH_EXEC_READ_REMOTE_OUTPUT_TIMEOUT = "jsch.exec.read.remote.output.timeout";
     private static final String DEFAULT_READ_REMOTE_OUTPUT_TIMEOUT = "180000";
 
     private final JschService jschService;
@@ -31,12 +31,14 @@ public class JschRemoteCommandExecutorServiceImpl implements RemoteCommandExecut
     public RemoteCommandReturnInfo executeCommand(final RemoteExecCommand remoteExecCommand) {
         if (remoteExecCommand.getCommand().getRunInShell()) {
             final int shellReadRemoteOutputTimeout =
-                    Integer.parseInt(ApplicationProperties.get(JSCH_SHELL_READ_REMOTE_OUTPUT_TIMEOUT, DEFAULT_READ_REMOTE_OUTPUT_TIMEOUT));
+                    Integer.parseInt(ApplicationProperties.get(JSCH_SHELL_READ_REMOTE_OUTPUT_TIMEOUT.getPropertyName(),
+                            DEFAULT_READ_REMOTE_OUTPUT_TIMEOUT));
             return jschService.runShellCommand(remoteExecCommand.getRemoteSystemConnection(),
                     remoteExecCommand.getCommand().toCommandString(), shellReadRemoteOutputTimeout);
         }
         final int execReadRemoteOutputTimeout =
-                Integer.parseInt(ApplicationProperties.get(JSCH_EXEC_READ_REMOTE_OUTPUT_TIMEOUT, DEFAULT_READ_REMOTE_OUTPUT_TIMEOUT));
+                Integer.parseInt(ApplicationProperties.get(JSCH_EXEC_READ_REMOTE_OUTPUT_TIMEOUT.getPropertyName(),
+                        DEFAULT_READ_REMOTE_OUTPUT_TIMEOUT));
         return jschService.runExecCommand(remoteExecCommand.getRemoteSystemConnection(),
                 remoteExecCommand.getCommand().toCommandString(), execReadRemoteOutputTimeout);
     }


### PR DESCRIPTION
Things included in this pull request

- Make read remote output a property file and set the default timeout to 180000 or 3 minutes
- Refactor code, eliminate redundant method names
- Refactor readExecRemoteOutput