### PR TITLE
tomcat manager.xml

### DIFF
--- a/jwala-common/src/main/java/com/cerner/jwala/common/properties/PropertyKeys.java
+++ b/jwala-common/src/main/java/com/cerner/jwala/common/properties/PropertyKeys.java
@@ -22,7 +22,8 @@ public enum PropertyKeys {
     REMOTE_PATHS_TOMCAT_ROOT_CORE("remote.paths.tomcat.root.core"),
     REMOTE_PATHS_TOMCAT_CORE("remote.paths.tomcat.core"),
     LOCAL_JWALA_BINARY_DIR("jwala.binary.dir"),
-    JMAP_DUMP_LIVE_ENABLED("jmap.dump.live.enabled");
+    JMAP_DUMP_LIVE_ENABLED("jmap.dump.live.enabled"),
+    TOMCAT_MANAGER_XML_SSL_PATH("tomcat.manager.xml.ssl.path");
 
 
     private String propertyName;

--- a/jwala-common/src/main/java/com/cerner/jwala/common/properties/PropertyKeys.java
+++ b/jwala-common/src/main/java/com/cerner/jwala/common/properties/PropertyKeys.java
@@ -23,7 +23,8 @@ public enum PropertyKeys {
     REMOTE_PATHS_TOMCAT_CORE("remote.paths.tomcat.core"),
     LOCAL_JWALA_BINARY_DIR("jwala.binary.dir"),
     JMAP_DUMP_LIVE_ENABLED("jmap.dump.live.enabled"),
-    TOMCAT_MANAGER_XML_SSL_PATH("tomcat.manager.xml.ssl.path");
+    TOMCAT_MANAGER_XML_SSL_PATH("tomcat.manager.xml.ssl.path"),
+    PATHS_RESOURCE_TEMPLATES("paths.resource-templates");
 
 
     private String propertyName;

--- a/jwala-services/src/main/java/com/cerner/jwala/service/jvm/impl/ManagedJvmBuilder.java
+++ b/jwala-services/src/main/java/com/cerner/jwala/service/jvm/impl/ManagedJvmBuilder.java
@@ -26,6 +26,7 @@ import java.nio.file.*;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.*;
 
+import static com.cerner.jwala.common.properties.PropertyKeys.PATHS_RESOURCE_TEMPLATES;
 import static com.cerner.jwala.common.properties.PropertyKeys.TOMCAT_MANAGER_XML_SSL_PATH;
 
 /**
@@ -35,7 +36,6 @@ public class ManagedJvmBuilder {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ManagedJvmBuilder.class);
 
-    private static final String PATHS_RESOURCE_TEMPLATES = "paths.resource-templates";
     private static final String INSTALL_SERVICE_TEMPLATE = "install-service-jvm.bat.tpl";
     private static final String SERVER_XML_TEMPLATE = "server.xml.tpl";
     public static final String INSTALL_SERVICE_BAT = "install-service.bat";
@@ -87,7 +87,7 @@ public class ManagedJvmBuilder {
 
         // check for the template and the destination property - both are required
         final String destManagerXmlPath = ApplicationProperties.get(TOMCAT_MANAGER_XML_SSL_PATH);
-        final String templatesPath = ApplicationProperties.getRequired("paths.resource-templates");
+        final String templatesPath = ApplicationProperties.getRequired(PATHS_RESOURCE_TEMPLATES);
         final String managerXmlFileName = "/manager.xml";
         final File srcManagerXmlFile = new File(templatesPath + managerXmlFileName);
         if (null == destManagerXmlPath || destManagerXmlPath.isEmpty() || !srcManagerXmlFile.exists()) {

--- a/jwala-services/src/test/resources/manager.xml
+++ b/jwala-services/src/test/resources/manager.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<!--
+
+    Context configuration file for the Tomcat Manager Web App
+
+-->
+<Context docBase="${STP_HOME}/app/webapps/tomcat-manager-7.0.55.war"
+         privileged="true" antiResourceLocking="false" antiJARLocking="false">
+
+</Context>

--- a/jwala-services/src/test/resources/managerXml/vars.properties
+++ b/jwala-services/src/test/resources/managerXml/vars.properties
@@ -1,0 +1,45 @@
+commands.scripts-path=./src/test/resources
+paths.resource-templates=./src/test/resources
+jwala.default.app.context=AppContextXMLTemplate.tpl
+jwala.default.role.mapping.properties=RoleMappingTemplate.tpl
+paths.generated.resource.dir=./build/generated
+remote.jwala.webapps.dir=./src/test/resources/webapps
+net.stop.sleep.time.seconds=20
+remote.paths.instances=d:/jwala/app/instances
+remote.paths.httpd.conf=d:/jwala/app/data/httpd
+test.jwala.property=found it!
+
+# binary distribution
+jwala.binary.dir=./src/test/resources/binaries
+jwala.binary.dir.jdk=jdk1.8.0_92
+jwala.binary.dir.tomcat=apache-tomcat-7.0.55
+jwala.binary.dir.webServer=apache-httpd-2.4.20
+jwala.binary.deploy.dir=D:/ctp
+
+remote.paths.tomcat.core=D:/ctp/apache-tomcat-7.0.55/core
+remote.paths.apache.httpd=D:/ctp/apache-httpd-2.4.20
+
+string.property=string property
+jwala.tomcat.zip.name=apache-tomcat-test.zip
+jwala.agent.dir=./build/resources/test/data/agent
+remote.commands.user-scripts=~/.jwala
+
+decryptExpression=new String(new org.apache.tomcat.util.codec.binary.Base64().decode((#stringToDecrypt).getBytes()))
+encryptExpression=new String (new org.apache.tomcat.util.codec.binary.Base64().encode((#stringToEncrypt).getBytes()))
+
+test.path.backslash={"deployPath":"\\server\d$"}
+test.path.backslash.escaped={"deployPath":"\\\\server\\d$"}
+test.path.backslash.escaped.escaped={"deployPath":"\\\\\\\\server\\\\d$"}
+
+remote.jwala.execution.timeout.seconds = 300
+remote.tomcat.dir.name=apache-tomcat-7.0.55
+jwala.apache.httpd.zip.name=apache-httpd-2.4.20.zip
+remote.paths.httpd.root.dir.name=c:/ctp
+remote.jwala.java.root.dir.name=jdk1.8.0_92
+remote.paths.deploy.dir=c:/ctp
+
+remote.jwala.data.dir=c:/ctp/data
+jmap.dump.live.enabled=false
+remote.jwala.java.home=c:/ctp/jdk
+
+tomcat.manager.xml.ssl.path=/conf/ssl/localhost


### PR DESCRIPTION
Place a manager.xml in the SSL directory of the JVM to allow monitoring of SSL enabled applications running on the JVM.

To enable the manager app in SSL 3 conditions need to be met:

1. In vars.properties the tomcat.manager.xml.ssl.path property must be set
2. In the data/templates directory of jwala there must be a manger.xml template
3. And for the Operations tab in the UI to use the SSL URL for the manager app, in vars.properties the tomcat.manager.protocol property must be set

The manager.xml is added to the generated JVM jar as an internal operation and does not show up as a resource in the UI.