### PR TITLE
Fix creation of extra jvm folder before unjar-jvm.sh

### DIFF
--- a/jwala-services/src/main/java/com/cerner/jwala/service/jvm/impl/JvmServiceImpl.java
+++ b/jwala-services/src/main/java/com/cerner/jwala/service/jvm/impl/JvmServiceImpl.java
@@ -622,15 +622,7 @@ public class JvmServiceImpl implements JvmService {
 
     private void deployJvmConfigJar(Jvm jvm, User user, String jvmJar) throws CommandFailureException {
         final String parentDir = ApplicationProperties.get("remote.paths.instances");
-        CommandOutput execData = jvmControlService.executeCreateDirectoryCommand(jvm, parentDir+"/"+jvm.getJvmName());
-        if (execData.getReturnCode().wasSuccessful()) {
-            LOGGER.info("Successfully created the parent directory {}", parentDir);
-        } else {
-            String standardError = execData.getStandardError().isEmpty() ? execData.getStandardOutput() : execData.getStandardError();
-            LOGGER.error("Deploy command completed with error trying to extract and back up JVM config {} :: ERROR: {}", jvm.getJvmName(), standardError);
-            throw new InternalErrorException(FaultType.REMOTE_COMMAND_FAILURE, standardError.isEmpty() ? CommandOutputReturnCode.fromReturnCode(execData.getReturnCode().getReturnCode()).getDesc() : standardError);
-        }
-        execData = jvmControlService.controlJvm(
+        CommandOutput execData = jvmControlService.controlJvm(
                 new ControlJvmRequest(jvm.getId(), JvmControlOperation.DEPLOY_CONFIG_ARCHIVE), user);
         execData.getStandardOutput();
         if (execData.getReturnCode().wasSuccessful()) {

--- a/jwala-tomcat/src/main/resources/data/scripts/unjar-jvm.sh
+++ b/jwala-tomcat/src/main/resources/data/scripts/unjar-jvm.sh
@@ -36,9 +36,17 @@ if $cygwin; then
       /usr/bin/echo JVM version not installed: $3 does not exist on this host
       exit $JWALA_EXIT_CODE_FAILED
     fi
-
+    #delete META-INF
+    if [ test -e "$2/META-INF" ]; then
+      echo delete "$2/META-INF"
+      /usr/bin/sudo rm -r "$2/META-INF"
+    fi
     $3 xf `cygpath -wa $1`
     /usr/bin/rm $1
+    #delete META-INF
+    if [ -e "$2/../META-INF" ]; then
+      rm -r "$2/../META-INF"
+    fi
     /usr/bin/echo Deploy of $1 was successful
     exit $JWALA_EXIT_CODE_SUCCESS
 fi
@@ -65,6 +73,10 @@ if $linux; then
     fi
 	$3 xf $1
     rm $1
+    #delete META-INF
+    if [ -e "$2/META-INF" ]; then
+      /usr/bin/sudo rm -r "$2/META-INF"
+    fi
     echo Deploy of $1 was successful
     exit $JWALA_EXIT_CODE_SUCCESS
 

--- a/jwala-tomcat/src/main/resources/data/scripts/unjar-jvm.sh
+++ b/jwala-tomcat/src/main/resources/data/scripts/unjar-jvm.sh
@@ -36,11 +36,6 @@ if $cygwin; then
       /usr/bin/echo JVM version not installed: $3 does not exist on this host
       exit $JWALA_EXIT_CODE_FAILED
     fi
-    #delete META-INF
-    if [ test -e "$2/META-INF" ]; then
-      echo delete "$2/META-INF"
-      /usr/bin/sudo rm -r "$2/META-INF"
-    fi
     $3 xf `cygpath -wa $1`
     /usr/bin/rm $1
     #delete META-INF
@@ -74,8 +69,8 @@ if $linux; then
 	$3 xf $1
     rm $1
     #delete META-INF
-    if [ -e "$2/META-INF" ]; then
-      /usr/bin/sudo rm -r "$2/META-INF"
+    if [ -e "$2/../META-INF" ]; then
+      /usr/bin/sudo rm -r "$2/../META-INF"
     fi
     echo Deploy of $1 was successful
     exit $JWALA_EXIT_CODE_SUCCESS


### PR DESCRIPTION
Fix creation of extra jvm folder before unjar-jvm.sh
Remove MET-INF folder from instances after unjar

Before you contribute, please review these guidelines to help ensure a smooth process for everyone.

Thanks.

* Read [how to properly contribute to open source projects on Github][1].
* Fork the project.
* Use a feature branch.
* Write [good commit messages][2].
* Use the same coding conventions as the rest of the project.
* Commit locally and push to your fork until you are happy with your contribution.
* Make sure to add tests and verify all the tests are passing when merging upstream.
* Add an entry to the [Changelog][3] accordingly.
* Please add your name to the [CONTRIBUTORS.md][7] file. Adding your name to the [CONTRIBUTORS.md][7] file signifies agreement to all rights and reservations provided by the [License][4].
* [Squash related commits together][5].
* Open a [pull request][6].
* The pull request will be reviewed by the community and merged by the project committers.

[1]: http://gun.io/blog/how-to-github-fork-branch-and-pull-request
[2]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[3]: ./CHANGELOG.md
[4]: ./LICENSE
[5]: http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html
[6]: https://help.github.com/articles/using-pull-requests
[7]: ./CONTRIBUTORS.md
