### PR TITLE
Fix for deploy of application resources not checking for started JVMs

### DIFF
--- a/jwala-services/src/main/java/com/cerner/jwala/service/app/impl/ApplicationServiceImpl.java
+++ b/jwala-services/src/main/java/com/cerner/jwala/service/app/impl/ApplicationServiceImpl.java
@@ -395,7 +395,7 @@ public class ApplicationServiceImpl implements ApplicationService {
     }
 
     @Override
-    @Transactional
+    @Transactional (readOnly = true)
     public void deployConf(final String appName, final String hostName, final User user) {
         final Application application = applicationPersistenceService.getApplication(appName);
         final Group group = groupPersistenceService.getGroup(application.getGroup().getId());

--- a/jwala-services/src/main/java/com/cerner/jwala/service/app/impl/ApplicationServiceImpl.java
+++ b/jwala-services/src/main/java/com/cerner/jwala/service/app/impl/ApplicationServiceImpl.java
@@ -242,11 +242,9 @@ public class ApplicationServiceImpl implements ApplicationService {
     }
 
     @Override
-    @Transactional
     public void deployApplicationResourcesToGroupHosts(String groupName, Application app, ResourceGroup resourceGroup) {
         List<String> appResourcesNames = groupPersistenceService.getGroupAppsResourceTemplateNames(groupName);
-        Group group = groupPersistenceService.getGroup(app.getGroup().getId());
-        final Set<Jvm> jvms = group.getJvms();
+        final List<Jvm> jvms = jvmPersistenceService.getJvmsByGroupName(groupName);
         if (null != appResourcesNames && !appResourcesNames.isEmpty()) {
             for (String resourceTemplateName : appResourcesNames) {
                 String metaDataStr = groupPersistenceService.getGroupAppResourceTemplateMetaData(groupName, resourceTemplateName);
@@ -259,7 +257,7 @@ public class ApplicationServiceImpl implements ApplicationService {
                             final String host = jvm.getHostName().toLowerCase(Locale.US);
                             if (!hostNames.contains(host)) {
                                 hostNames.add(host);
-                                executeDeployGroupAppTemplate(group.getName(), resourceTemplateName, app, jvm.getHostName());
+                                executeDeployGroupAppTemplate(groupName, resourceTemplateName, app, jvm.getHostName());
                             }
                         }
 
@@ -395,7 +393,6 @@ public class ApplicationServiceImpl implements ApplicationService {
     }
 
     @Override
-    @Transactional (readOnly = true)
     public void deployConf(final String appName, final String hostName, final User user) {
         final Application application = applicationPersistenceService.getApplication(appName);
         final Group group = groupPersistenceService.getGroup(application.getGroup().getId());
@@ -461,7 +458,8 @@ public class ApplicationServiceImpl implements ApplicationService {
     protected void checkForRunningJvms(final Group group, final List<String> hostNames, final User user) {
         final Set<Jvm> runningJvmList = new HashSet<>();
         final List<String> runningJvmNameList = new ArrayList<>();
-        for (final Jvm jvm : group.getJvms()) {
+        List<Jvm> jvmsInGroup = jvmPersistenceService.getJvmsByGroupName(group.getName());
+        for (final Jvm jvm : jvmsInGroup) {
             if (hostNames.contains(jvm.getHostName().toLowerCase(Locale.US)) && jvm.getState().isStartedState()) {
                 runningJvmList.add(jvm);
                 runningJvmNameList.add(jvm.getJvmName());

--- a/jwala-services/src/main/java/com/cerner/jwala/service/app/impl/ApplicationServiceImpl.java
+++ b/jwala-services/src/main/java/com/cerner/jwala/service/app/impl/ApplicationServiceImpl.java
@@ -395,6 +395,7 @@ public class ApplicationServiceImpl implements ApplicationService {
     }
 
     @Override
+    @Transactional
     public void deployConf(final String appName, final String hostName, final User user) {
         final Application application = applicationPersistenceService.getApplication(appName);
         final Group group = groupPersistenceService.getGroup(application.getGroup().getId());

--- a/jwala-services/src/main/java/com/cerner/jwala/service/group/impl/GroupServiceImpl.java
+++ b/jwala-services/src/main/java/com/cerner/jwala/service/group/impl/GroupServiceImpl.java
@@ -402,12 +402,11 @@ public class GroupServiceImpl implements GroupService {
         return new ArrayList<>(allHosts);
     }
 
-    @Transactional
     @Override
     @SuppressWarnings("unchecked")
     public Group generateAndDeployGroupJvmFile(final String groupName, final String fileName, final User user) {
         final Group group = groupPersistenceService.getGroup(groupName);
-        final Set<Jvm> jvms = group.getJvms();
+        final List<Jvm> jvms = jvmService.getJvmsByGroupName(group.getName());
 
         // Check if any JVMs are running before generating the file
         final List<String> startedJvmNameList = new ArrayList<>();

--- a/jwala-services/src/main/java/com/cerner/jwala/service/jvm/JvmService.java
+++ b/jwala-services/src/main/java/com/cerner/jwala/service/jvm/JvmService.java
@@ -113,4 +113,10 @@ public interface JvmService {
      */
     void deleteJvm(String name, String userName);
 
+    /**
+     * Return the JVMs belonging to a group
+     * @param name the name of the group of the JVMs
+     * @return a collection of JVMs belonging to the group
+     */
+    List<Jvm> getJvmsByGroupName(String name);
 }

--- a/jwala-services/src/main/java/com/cerner/jwala/service/jvm/impl/JvmServiceImpl.java
+++ b/jwala-services/src/main/java/com/cerner/jwala/service/jvm/impl/JvmServiceImpl.java
@@ -242,6 +242,11 @@ public class JvmServiceImpl implements JvmService {
     }
 
     @Override
+    public List<Jvm> getJvmsByGroupName(String name) {
+        return jvmPersistenceService.getJvmsByGroupName(name);
+    }
+
+    @Override
     @Transactional
     public Jvm updateJvm(final UpdateJvmRequest updateJvmRequest, final boolean updateJvmPassword) {
 

--- a/jwala-services/src/test/java/com/cerner/jwala/service/app/impl/ApplicationServiceImplTest.java
+++ b/jwala-services/src/test/java/com/cerner/jwala/service/app/impl/ApplicationServiceImplTest.java
@@ -371,7 +371,7 @@ public class ApplicationServiceImplTest {
         hosts.add("testServer2");
         List<String> templateNames = new ArrayList<>();
         templateNames.add("");
-        Set<Jvm> jvms = new HashSet<>();
+        List<Jvm> jvms = new ArrayList<>();
         ResourceTemplateMetaData mockMetaData = mock(ResourceTemplateMetaData.class);
         Entity mockEntity = mock(Entity.class);
         Jvm mockJvm = mock(Jvm.class);
@@ -384,8 +384,7 @@ public class ApplicationServiceImplTest {
         when(Config.mockApplication.getGroup()).thenReturn(mockGroup);
         when(mockGroup.getName()).thenReturn("test-group");
         when(mockGroup.getId()).thenReturn(new Identifier<Group>(1L));
-        when(mockGroup.getJvms()).thenReturn(jvms);
-        when(mockJvm.getHostName()).thenReturn("testserver");
+       when(mockJvm.getHostName()).thenReturn("testserver");
         when(mockJvm.getState()).thenReturn(JvmState.JVM_NEW);
         when(Config.mockGroupPersistenceService.getHosts(anyString())).thenReturn(hosts);
         when(Config.mockGroupPersistenceService.getGroupAppResourceTemplateMetaData(anyString(), anyString())).thenReturn("");
@@ -396,6 +395,7 @@ public class ApplicationServiceImplTest {
         when(Config.mockResourceService.generateAndDeployFile(any(ResourceIdentifier.class), anyString(), anyString(),
                 anyString())).thenReturn(mockCommandOutput);
         when(mockCommandOutput.getReturnCode()).thenReturn(new ExecReturnCode(0));
+        when(Config.jvmPersistenceService.getJvmsByGroupName(anyString())).thenReturn(jvms);
         applicationService.deployConf(appName, null, testUser);
         verify(Config.mockResourceService, times(2)).generateAndDeployFile(any(ResourceIdentifier.class), anyString(),
                 anyString(), anyString());
@@ -454,18 +454,22 @@ public class ApplicationServiceImplTest {
         List<String> hosts = new ArrayList<>();
         hosts.add("testServer");
         hosts.add("testServer2");
-        Set<Jvm> jvms = new HashSet<>();
+        List<Jvm> jvms = new ArrayList<>();
         Jvm mockJvm = mock(Jvm.class);
         jvms.add(mockJvm);
         Group mockGroup = mock(Group.class);
         when(Config.applicationPersistenceService.getApplication(eq(appName))).thenReturn(Config.mockApplication);
         when(Config.mockGroupPersistenceService.getGroup(any(Identifier.class))).thenReturn(mockGroup);
         when(Config.mockApplication.getGroup()).thenReturn(mockGroup);
+
         when(mockGroup.getId()).thenReturn(new Identifier<Group>(1L));
-        when(mockGroup.getJvms()).thenReturn(jvms);
+        when(mockGroup.getName()).thenReturn("mockGroupName");
         when(mockJvm.getHostName()).thenReturn("testserver");
         when(mockJvm.getState()).thenReturn(JvmState.JVM_STARTED);
+
         when(Config.mockGroupPersistenceService.getHosts(anyString())).thenReturn(hosts);
+
+        when(Config.jvmPersistenceService.getJvmsByGroupName(anyString())).thenReturn(jvms);
         applicationService.deployConf(appName, null, testUser);
     }
 
@@ -599,7 +603,6 @@ public class ApplicationServiceImplTest {
         Group mockGroup = mock(Group.class);
         when(mockGroup.getName()).thenReturn("mock-group-name");
         when(mockGroup.getId()).thenReturn(new Identifier<Group>(999L));
-        when(mockGroup.getJvms()).thenReturn(Collections.singleton(mockJvm));
 
         Application mockApplicationForDeploy = mock(Application.class);
         when(mockApplicationForDeploy.getGroup()).thenReturn(mockGroup);
@@ -620,6 +623,7 @@ public class ApplicationServiceImplTest {
         when(Config.mockGroupPersistenceService.getGroupAppResourceTemplateMetaData(anyString(), anyString())).thenReturn("{\"fake\":\"meta-data\"}");
         when(Config.mockResourceService.getTokenizedMetaData(anyString(), anyObject(), anyString())).thenReturn(mockResourceTemplateMetaData);
         when(Config.mockResourceService.generateAndDeployFile(any(ResourceIdentifier.class), anyString(), anyString(), anyString())).thenReturn(new CommandOutput(new ExecReturnCode(0), "Generate and deploy succeeded", ""));
+        when(Config.jvmPersistenceService.getJvmsByGroupName(anyString())).thenReturn(Collections.singletonList(mockJvm));
 
         applicationService.deployApplicationResourcesToGroupHosts("mock-group-name", mockApplicationForDeploy, mockResourceGroup);
 


### PR DESCRIPTION
The cause of the issue was that the group object being returned was not populating its list of JVMs. Adding the Transactional annotation to the deploy method makes sure that the JVM mapping to the group is honored when retrieving the group object.