### PR TITLE
Uploading non-war file in web archive of web app instead of War file

### DIFF
--- a/jwala-webapp/src/main/webapp/resources/js/react/WebAppConfig.js
+++ b/jwala-webapp/src/main/webapp/resources/js/react/WebAppConfig.js
@@ -323,7 +323,7 @@ var UploadWarWidget = React.createClass({
                    <form ref="warUploadForm">
                        <label>*WAR File</label>
                        <label ref="fileInputLabel" htmlFor="fileInput" className="error"/>
-                       <input ref="fileInput" name="fileInput" type="file" required onChange={this.onChangeFileInput}/>
+                       <input ref="fileInput" name="fileInput" type="file" accept=".war" required onChange={this.onChangeFileInput}/>
                        <br/>
                        <input type="checkbox" value={this.state.assignToJvms} onChange={this.onChangeAssignToJvms}>
                            <span>Assign to JVMs</span>


### PR DESCRIPTION
 I have discussed with Jedd, since we use upload resource in general for all files type even from UI or rest service, there is no validation in the back end to check if this is just for web application war, so I add the upload file (filter by .war) to let user to choice the .war file. If we need more validation in the back end we need to send our rest call with request type such as from rest call or from UI, from jvm or from webserver or from application, from application for web war or for web xml and etc. This involve all detail check for each different type of resource. So we decide only do the UI filter for now and need more discussion for back end validation. 

No error thrown + file uploaded on remote server.