### PR TITLE
Sorted jvms by name in resources list

### DIFF
--- a/jwala-persistence/src/main/java/com/cerner/jwala/persistence/jpa/domain/JpaJvm.java
+++ b/jwala-persistence/src/main/java/com/cerner/jwala/persistence/jpa/domain/JpaJvm.java
@@ -15,7 +15,7 @@ import java.util.List;
         @NamedQuery(name = JpaJvm.QUERY_UPDATE_STATE_AND_ERR_STS_BY_ID, query = "UPDATE JpaJvm j SET j.state = :state, j.errorStatus = :errorStatus, j.lastUpdateDate = CURRENT_TIMESTAMP WHERE j.id = :id"),
         @NamedQuery(name = JpaJvm.QUERY_GET_JVM_COUNT_BY_STATE_AND_GROUP_NAME, query = "SELECT COUNT(1) FROM JpaJvm j WHERE j.state = :state AND j.groups.name = :groupName"),
         @NamedQuery(name = JpaJvm.QUERY_GET_JVM_COUNT_BY_GROUP_NAME, query = "SELECT COUNT(1) FROM JpaJvm j WHERE j.groups.name = :groupName"),
-        @NamedQuery(name = JpaJvm.QUERY_GET_JVMS_BY_GROUP_NAME, query = "SELECT j FROM JpaJvm j WHERE j.groups.name = :groupName"),
+        @NamedQuery(name = JpaJvm.QUERY_GET_JVMS_BY_GROUP_NAME, query = "SELECT j FROM JpaJvm j WHERE j.groups.name = :groupName ORDER by j.name"),
         @NamedQuery(name = JpaJvm.QUERY_GET_JVM_ID, query = "SELECT j.id FROM JpaJvm j WHERE j.name = :name")
 })
 public class JpaJvm extends AbstractEntity<JpaJvm> {

--- a/jwala-persistence/src/main/java/com/cerner/jwala/persistence/jpa/service/impl/JvmCrudServiceImpl.java
+++ b/jwala-persistence/src/main/java/com/cerner/jwala/persistence/jpa/service/impl/JvmCrudServiceImpl.java
@@ -22,7 +22,6 @@ import org.slf4j.LoggerFactory;
 
 import javax.persistence.*;
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.List;
 
 public class JvmCrudServiceImpl extends AbstractCrudServiceImpl<JpaJvm> implements JvmCrudService {
@@ -360,14 +359,7 @@ public class JvmCrudServiceImpl extends AbstractCrudServiceImpl<JpaJvm> implemen
     public List<Jvm> getJvmsByGroupName(String groupName) {
         final Query q = entityManager.createNamedQuery(JpaJvm.QUERY_GET_JVMS_BY_GROUP_NAME);
         q.setParameter(JpaJvm.QUERY_PARAM_GROUP_NAME, groupName);
-        List<Jvm> listOfJvms=buildJvms(q.getResultList());
-        listOfJvms.sort(new Comparator<Jvm>() {
-            @Override
-            public int compare(Jvm jvm1, Jvm jvm2) {
-                return jvm1.getJvmName().compareTo(jvm2.getJvmName());
-            }
-        });
-        return listOfJvms;
+        return buildJvms(q.getResultList());
     }
 
     /**

--- a/jwala-persistence/src/main/java/com/cerner/jwala/persistence/jpa/service/impl/JvmCrudServiceImpl.java
+++ b/jwala-persistence/src/main/java/com/cerner/jwala/persistence/jpa/service/impl/JvmCrudServiceImpl.java
@@ -22,6 +22,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.persistence.*;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 
 public class JvmCrudServiceImpl extends AbstractCrudServiceImpl<JpaJvm> implements JvmCrudService {
@@ -359,7 +360,14 @@ public class JvmCrudServiceImpl extends AbstractCrudServiceImpl<JpaJvm> implemen
     public List<Jvm> getJvmsByGroupName(String groupName) {
         final Query q = entityManager.createNamedQuery(JpaJvm.QUERY_GET_JVMS_BY_GROUP_NAME);
         q.setParameter(JpaJvm.QUERY_PARAM_GROUP_NAME, groupName);
-        return buildJvms(q.getResultList());
+        List<Jvm> listOfJvms=buildJvms(q.getResultList());
+        listOfJvms.sort(new Comparator<Jvm>() {
+            @Override
+            public int compare(Jvm jvm1, Jvm jvm2) {
+                return jvm1.getJvmName().compareTo(jvm2.getJvmName());
+            }
+        });
+        return listOfJvms;
     }
 
     /**


### PR DESCRIPTION
The JVMs are not sorted in any order, in the resources topology under the group.
Added a comparator, so that the JVM list, is sorted by the JVM name, and is displayed alphabetically.


Before you contribute, please review these guidelines to help ensure a smooth process for everyone.

Thanks.

* Read [how to properly contribute to open source projects on Github][1].
* Fork the project.
* Use a feature branch.
* Write [good commit messages][2].
* Use the same coding conventions as the rest of the project.
* Commit locally and push to your fork until you are happy with your contribution.
* Make sure to add tests and verify all the tests are passing when merging upstream.
* Add an entry to the [Changelog][3] accordingly.
* Please add your name to the [CONTRIBUTORS.md][7] file. Adding your name to the [CONTRIBUTORS.md][7] file signifies agreement to all rights and reservations provided by the [License][4].
* [Squash related commits together][5].
* Open a [pull request][6].
* The pull request will be reviewed by the community and merged by the project committers.

[1]: http://gun.io/blog/how-to-github-fork-branch-and-pull-request
[2]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[3]: ./CHANGELOG.md
[4]: ./LICENSE
[5]: http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html
[6]: https://help.github.com/articles/using-pull-requests
[7]: ./CONTRIBUTORS.md
