### PR TITLE
Make jvm webserver delete consistent part 2

### DIFF
--- a/jwala-services/src/main/java/com/cerner/jwala/service/group/GroupStateNotificationService.java
+++ b/jwala-services/src/main/java/com/cerner/jwala/service/group/GroupStateNotificationService.java
@@ -1,6 +1,11 @@
 package com.cerner.jwala.service.group;
 
+import com.cerner.jwala.common.domain.model.group.Group;
 import com.cerner.jwala.common.domain.model.id.Identifier;
+import com.cerner.jwala.common.domain.model.state.CurrentState;
+import com.cerner.jwala.common.domain.model.state.OperationalState;
+
+import java.util.Map;
 
 /**
  * Retrieve group state details (e.g. running JVM count and Web Sever count) and send the said data to a destination via
@@ -16,5 +21,17 @@ public interface GroupStateNotificationService {
      * @param aClass the class where the state belongs to.
      */
     void retrieveStateAndSend(Identifier id, Class aClass);
+
+    /**
+     * Gets a group's state
+     * @return A group's curent state
+     */
+    CurrentState<Group, OperationalState> getGroupState(String groupName);
+
+    /**
+     * Gets a group's state
+     * @return A group's curent state
+     */
+    Map<String, CurrentState<Group, OperationalState>> getGroupStates();
 
 }

--- a/jwala-services/src/main/java/com/cerner/jwala/service/jvm/impl/JvmServiceImpl.java
+++ b/jwala-services/src/main/java/com/cerner/jwala/service/jvm/impl/JvmServiceImpl.java
@@ -281,7 +281,8 @@ public class JvmServiceImpl implements JvmService {
         if (hardDelete) {
             LOGGER.info("Deleting JVM service {}", jvm.getJvmName());
 
-            if (!JvmState.JVM_STOPPED.equals(jvm.getState()) && !JvmState.FORCED_STOPPED.equals(jvm.getState())) {
+            if (!JvmState.JVM_NEW.equals(jvm.getState()) && !JvmState.JVM_STOPPED.equals(jvm.getState()) &&
+                    !JvmState.FORCED_STOPPED.equals(jvm.getState())) {
                 final String msg = MessageFormat.format("Please stop JVM {0} first before attempting to delete it",
                         jvm.getJvmName());
                 LOGGER.warn(msg); // this is not a system error hence we only log it as a warning even though we throw

--- a/jwala-services/src/main/java/com/cerner/jwala/service/jvm/impl/JvmServiceImpl.java
+++ b/jwala-services/src/main/java/com/cerner/jwala/service/jvm/impl/JvmServiceImpl.java
@@ -290,15 +290,17 @@ public class JvmServiceImpl implements JvmService {
                 throw new JvmServiceException(msg);
             }
 
-            // delete the service
-            final CommandOutput commandOutput = jvmControlService.controlJvm(new ControlJvmRequest(jvm.getId(),
-                    JvmControlOperation.DELETE_SERVICE), user);
-            if (!commandOutput.getReturnCode().wasSuccessful()) {
-                final String msg = MessageFormat.format("Failed to delete the JVM service {0}! CommandOutput = {1}",
-                        jvm.getJvmName(), commandOutput);
-                LOGGER.error(msg);
-                throw new JvmServiceException(msg);
+            if (!JvmState.JVM_NEW.equals(jvm.getState())) {
+                final CommandOutput commandOutput = jvmControlService.controlJvm(new ControlJvmRequest(jvm.getId(),
+                        JvmControlOperation.DELETE_SERVICE), user);
+                if (!commandOutput.getReturnCode().wasSuccessful()) {
+                    final String msg = MessageFormat.format("Failed to delete the JVM service {0}! CommandOutput = {1}",
+                            jvm.getJvmName(), commandOutput);
+                    LOGGER.error(msg);
+                    throw new JvmServiceException(msg);
+                }
             }
+
         }
 
         jvmPersistenceService.removeJvm(id);

--- a/jwala-services/src/main/java/com/cerner/jwala/service/webserver/impl/WebServerServiceImpl.java
+++ b/jwala-services/src/main/java/com/cerner/jwala/service/webserver/impl/WebServerServiceImpl.java
@@ -180,14 +180,15 @@ public class WebServerServiceImpl implements WebServerService {
                 throw new WebServerServiceException(msg);
             }
 
-            // delete the service
-            final CommandOutput commandOutput = webServerControlService.controlWebServer(new ControlWebServerRequest(webServer.getId(),
-                    WebServerControlOperation.DELETE_SERVICE), user);
-            if (!commandOutput.getReturnCode().wasSuccessful()) {
-                final String msg = MessageFormat.format("Failed to delete the web server service {0}! CommandOutput = {1}",
-                        webServer.getName(), commandOutput);
-                LOGGER.error(msg);
-                throw new WebServerServiceException(msg);
+            if (!WebServerReachableState.WS_NEW.equals(webServer.getState())) {
+                final CommandOutput commandOutput = webServerControlService.controlWebServer(new ControlWebServerRequest(webServer.getId(),
+                        WebServerControlOperation.DELETE_SERVICE), user);
+                if (!commandOutput.getReturnCode().wasSuccessful()) {
+                    final String msg = MessageFormat.format("Failed to delete the web server service {0}! CommandOutput = {1}",
+                            webServer.getName(), commandOutput);
+                    LOGGER.error(msg);
+                    throw new WebServerServiceException(msg);
+                }
             }
         }
 
@@ -198,7 +199,8 @@ public class WebServerServiceImpl implements WebServerService {
     @Override
     public boolean isStarted(WebServer webServer) {
         final WebServerReachableState state = webServer.getState();
-        return !WebServerReachableState.WS_UNREACHABLE.equals(state) && !WebServerReachableState.WS_NEW.equals(state);
+        return !WebServerReachableState.WS_UNREACHABLE.equals(state) && !WebServerReachableState.FORCED_STOPPED.equals(state)
+                && !WebServerReachableState.WS_NEW.equals(state);
     }
 
     @Override

--- a/jwala-services/src/test/java/com/cerner/jwala/service/group/impl/spring/component/GroupStateNotificationServiceImplTest.java
+++ b/jwala-services/src/test/java/com/cerner/jwala/service/group/impl/spring/component/GroupStateNotificationServiceImplTest.java
@@ -7,6 +7,7 @@ import com.cerner.jwala.common.domain.model.state.CurrentState;
 import com.cerner.jwala.common.domain.model.state.OperationalState;
 import com.cerner.jwala.persistence.jpa.domain.JpaGroup;
 import com.cerner.jwala.persistence.jpa.domain.JpaJvm;
+import com.cerner.jwala.persistence.jpa.service.GroupCrudService;
 import com.cerner.jwala.persistence.jpa.service.JvmCrudService;
 import com.cerner.jwala.persistence.jpa.service.WebServerCrudService;
 import com.cerner.jwala.service.MessagingService;
@@ -34,6 +35,9 @@ public class GroupStateNotificationServiceImplTest {
     private GroupStateNotificationServiceImpl groupStateNotificationServiceImpl;
 
     @Mock
+    private GroupCrudService mockGroupCrudService;
+
+    @Mock
     private JvmCrudService mockJvmCrudService;
 
     @Mock
@@ -45,8 +49,8 @@ public class GroupStateNotificationServiceImplTest {
     @Before
     public void setup() {
         MockitoAnnotations.initMocks(this);
-        groupStateNotificationServiceImpl = new GroupStateNotificationServiceImpl(mockJvmCrudService, mockWebServerCrudService,
-                new TesterMessagingService());
+        groupStateNotificationServiceImpl = new GroupStateNotificationServiceImpl(mockGroupCrudService, mockJvmCrudService,
+                mockWebServerCrudService, new TesterMessagingService());
     }
 
     @Test

--- a/jwala-services/src/test/java/com/cerner/jwala/service/jvm/impl/JvmServiceImplTest.java
+++ b/jwala-services/src/test/java/com/cerner/jwala/service/jvm/impl/JvmServiceImplTest.java
@@ -867,7 +867,7 @@ public class JvmServiceImplTest extends VerificationBehaviorSupport {
     }
 
     @Test
-    public void testDeleteNewJvms() {
+    public void testDeleteNewJvm() {
         when(mockJvm.getState()).thenReturn(JvmState.JVM_NEW);
         when(Config.mockJvmPersistenceService.getJvm(id)).thenReturn(mockJvm);
         jvmService.deleteJvm(id, false, user);
@@ -876,7 +876,7 @@ public class JvmServiceImplTest extends VerificationBehaviorSupport {
     }
 
     @Test
-    public void testDeleteStoppedJvms() {
+    public void testDeleteStoppedJvm() {
         final CommandOutput mockCommandOutput = mock(CommandOutput.class);
         when(mockJvm.getState()).thenReturn(JvmState.JVM_STOPPED);
         when(Config.mockJvmPersistenceService.getJvm(id)).thenReturn(mockJvm);
@@ -888,7 +888,7 @@ public class JvmServiceImplTest extends VerificationBehaviorSupport {
     }
 
     @Test
-    public void testDeleteForcedStoppedJvms() {
+    public void testDeleteForcedStoppedJvm() {
         final CommandOutput mockCommandOutput = mock(CommandOutput.class);
         when(mockJvm.getState()).thenReturn(JvmState.JVM_STOPPED);
         when(Config.mockJvmPersistenceService.getJvm(id)).thenReturn(mockJvm);
@@ -912,7 +912,7 @@ public class JvmServiceImplTest extends VerificationBehaviorSupport {
     }
 
     @Test
-    public void testFailedDeleteServiceOfStoppedJvms() {
+    public void testFailedDeleteServiceOfStoppedJvm() {
         final CommandOutput mockCommandOutput = mock(CommandOutput.class);
         when(mockJvm.getJvmName()).thenReturn("testJvm");
         when(mockJvm.getState()).thenReturn(JvmState.JVM_STOPPED);
@@ -929,7 +929,7 @@ public class JvmServiceImplTest extends VerificationBehaviorSupport {
     }
 
     @Test
-    public void testDeleteNonStoppedAndNotNewJvms() {
+    public void testDeleteNonStoppedAndNotNewJvm() {
         when(mockJvm.getState()).thenReturn(JvmState.JVM_STARTED);
         when(Config.mockJvmPersistenceService.getJvm(id)).thenReturn(mockJvm);
         try {

--- a/jwala-services/src/test/java/com/cerner/jwala/service/jvm/impl/JvmServiceImplTest.java
+++ b/jwala-services/src/test/java/com/cerner/jwala/service/jvm/impl/JvmServiceImplTest.java
@@ -907,7 +907,7 @@ public class JvmServiceImplTest extends VerificationBehaviorSupport {
         when(mockCommandOutput.getReturnCode()).thenReturn(new ExecReturnCode(0));
         when(Config.mockJvmControlService.controlJvm(any(ControlJvmRequest.class), eq(user))).thenReturn(mockCommandOutput);
         jvmService.deleteJvm(id, true, user);
-        verify(Config.mockJvmControlService).controlJvm(any(ControlJvmRequest.class), eq(user));
+        verify(Config.mockJvmControlService, never()).controlJvm(any(ControlJvmRequest.class), eq(user));
         verify(Config.mockJvmPersistenceService).removeJvm(id);
     }
 

--- a/jwala-services/src/test/java/com/cerner/jwala/service/jvm/impl/JvmServiceImplTest.java
+++ b/jwala-services/src/test/java/com/cerner/jwala/service/jvm/impl/JvmServiceImplTest.java
@@ -900,6 +900,18 @@ public class JvmServiceImplTest extends VerificationBehaviorSupport {
     }
 
     @Test
+    public void testDeleteNewJvmWithHardDeleteOption() {
+        final CommandOutput mockCommandOutput = mock(CommandOutput.class);
+        when(mockJvm.getState()).thenReturn(JvmState.JVM_NEW);
+        when(Config.mockJvmPersistenceService.getJvm(id)).thenReturn(mockJvm);
+        when(mockCommandOutput.getReturnCode()).thenReturn(new ExecReturnCode(0));
+        when(Config.mockJvmControlService.controlJvm(any(ControlJvmRequest.class), eq(user))).thenReturn(mockCommandOutput);
+        jvmService.deleteJvm(id, true, user);
+        verify(Config.mockJvmControlService).controlJvm(any(ControlJvmRequest.class), eq(user));
+        verify(Config.mockJvmPersistenceService).removeJvm(id);
+    }
+
+    @Test
     public void testFailedDeleteServiceOfStoppedJvms() {
         final CommandOutput mockCommandOutput = mock(CommandOutput.class);
         when(mockJvm.getJvmName()).thenReturn("testJvm");

--- a/jwala-services/src/test/java/com/cerner/jwala/service/webserver/impl/WebServerServiceImplTest.java
+++ b/jwala-services/src/test/java/com/cerner/jwala/service/webserver/impl/WebServerServiceImplTest.java
@@ -408,6 +408,15 @@ public class WebServerServiceImplTest {
     }
 
     @Test
+    public void testDeleteNewWebServerWithHardOption() {
+        when(mockWebServer.getState()).thenReturn(WebServerReachableState.WS_NEW);
+        when(Config.mockWebServerPersistenceService.getWebServer(id)).thenReturn(mockWebServer);
+        wsService.deleteWebServer(id, true, user);
+        verify(Config.mockWebServerControlService, never()).controlWebServer(any(ControlWebServerRequest.class), eq(user));
+        verify(Config.mockWebServerPersistenceService).removeWebServer(id);
+    }
+
+    @Test
     public void testDeleteStoppedWebServer() {
         final CommandOutput mockCommandOutput = mock(CommandOutput.class);
         when(mockWebServer.getState()).thenReturn(WebServerReachableState.WS_UNREACHABLE);

--- a/jwala-webapp/src/main/webapp/resources/js/react/group-operations/GroupOperationsDataTable.js
+++ b/jwala-webapp/src/main/webapp/resources/js/react/group-operations/GroupOperationsDataTable.js
@@ -844,7 +844,7 @@ var GroupOperationsDataTable = React.createClass({
         let self = this;
         jvmService.deleteJvm(data.id.id, true).then(function(e){
             // Remove deleted row
-            $("tr td:contains('" + data.jvmName + "')").filter(function() {
+            $("td:contains('" + data.jvmName + "')").filter(function() {
                 if ($(this).text() === data.jvmName) {
                     $(this).parent().remove();
                 }

--- a/jwala-webapp/src/main/webapp/resources/js/react/group-operations/GroupOperationsDataTable.js
+++ b/jwala-webapp/src/main/webapp/resources/js/react/group-operations/GroupOperationsDataTable.js
@@ -816,7 +816,7 @@ var GroupOperationsDataTable = React.createClass({
         let self = this;
         webServerService.deleteWebServer(data.id.id, true).then(function(e){
             // Remove deleted row
-            $("td:contains('" + data.name + "')").filter(function() {
+             $("[id*='ws-child-table']").find("td:contains('" + data.name + "')").filter(function() {
                 if ($(this).text() === data.name) {
                     $(this).parent().remove();
                 }
@@ -844,7 +844,7 @@ var GroupOperationsDataTable = React.createClass({
         let self = this;
         jvmService.deleteJvm(data.id.id, true).then(function(e){
             // Remove deleted row
-            $("td:contains('" + data.jvmName + "')").filter(function() {
+            $("[id*='jvm-child-table']").find("td:contains('" + data.jvmName + "')").filter(function() {
                 if ($(this).text() === data.jvmName) {
                     $(this).parent().remove();
                 }

--- a/jwala-webapp/src/main/webapp/resources/js/react/group-operations/JvmControlPanelWidget.js
+++ b/jwala-webapp/src/main/webapp/resources/js/react/group-operations/JvmControlPanelWidget.js
@@ -42,7 +42,9 @@ var JvmControlPanelWidget = React.createClass({
                             className="zero-padding ui-widget ui-state-default ui-corner-all ui-button-text-only ui-button-height"
                             spanClassName="ui-icon ui-icon-trash"
                             onClick={this.jvmDelete}
-                            title="Delete JVM"/>
+                            title="Delete JVM"
+                            disabled = {!MainArea.isAdminRole}
+                            disabledTitle="Only users with admin role can access this feature"/>
 
                    <RButton ref="heapDumpBtn"
                             className="zero-padding ui-widget ui-state-default ui-corner-all ui-button-text-only ui-button-height"

--- a/jwala-webapp/src/main/webapp/resources/js/react/group-operations/WebServerControlPanelWidget.js
+++ b/jwala-webapp/src/main/webapp/resources/js/react/group-operations/WebServerControlPanelWidget.js
@@ -36,7 +36,9 @@ var WebServerControlPanelWidget = React.createClass({
                              className="ui-button ui-widget ui-state-default ui-corner-all ui-button-text-only ui-button-height"
                              spanClassName="ui-icon ui-icon-trash"
                              onClick={this.webServerDelete}
-                             title="Delete Web Server"/>
+                             title="Delete Web Server"
+                             disabled = {!MainArea.isAdminRole}
+                             disabledTitle="Only users with admin role can access this feature"/>
 
                     <button ref="httpdConfBtn" className="button-link anchor-font-style">httpd.conf</button>
 

--- a/jwala-webapp/src/main/webapp/resources/js/react/jvm-config.js
+++ b/jwala-webapp/src/main/webapp/resources/js/react/jvm-config.js
@@ -159,7 +159,9 @@ var JvmConfig = React.createClass({
             if (doneCallback) {
                 doneCallback();
             }
-            self.setState({"groupData": groupData, "jvmTableData": response.applicationResponseContent});
+            states["groupData"] = groupData;
+            states["jvmTableData"] = response.applicationResponseContent;
+            self.setState(states);
         }).caught(function(response){
             console.log(response);
             self.setState({err: response});

--- a/jwala-webapp/src/main/webapp/resources/js/react/webserver-config.js
+++ b/jwala-webapp/src/main/webapp/resources/js/react/webserver-config.js
@@ -158,7 +158,9 @@ var WebServerConfig = React.createClass({
             if (doneCallback) {
                 doneCallback();
             }
-            self.setState({"groupData": groupData, "webServerTableData": response.applicationResponseContent});
+            states["groupData"] = groupData;
+            states["webServerTableData"] = response.applicationResponseContent;
+            self.setState(states);
         }).caught(function(response){
             console.log(response);
             self.setState({err: response});

--- a/jwala-webservices/src/main/java/com/cerner/jwala/ws/rest/v1/service/group/GroupServiceRest.java
+++ b/jwala-webservices/src/main/java/com/cerner/jwala/ws/rest/v1/service/group/GroupServiceRest.java
@@ -263,4 +263,22 @@ public interface GroupServiceRest {
     @GET
     @Path("/hosts")
     Response getAllHosts();
+
+    /**
+     * Returns the state of a group
+     * @param groupName the name of the group
+     * @return state info of a group
+     */
+    @GET
+    @Path("/{groupName}/state")
+    Response getGroupState(@PathParam("groupName") String groupName);
+
+    /**
+     * Gets the state info of all groups
+     * @return state info of all groups
+     */
+    @GET
+    @Path("/state")
+    Response getGroupStates();
+
 }

--- a/jwala-webservices/src/main/java/com/cerner/jwala/ws/rest/v1/service/group/impl/GroupServiceRestImpl.java
+++ b/jwala-webservices/src/main/java/com/cerner/jwala/ws/rest/v1/service/group/impl/GroupServiceRestImpl.java
@@ -22,10 +22,7 @@ import com.cerner.jwala.persistence.jpa.service.exception.NonRetrievableResource
 import com.cerner.jwala.persistence.jpa.service.exception.ResourceTemplateUpdateException;
 import com.cerner.jwala.service.app.ApplicationService;
 import com.cerner.jwala.service.exception.GroupServiceException;
-import com.cerner.jwala.service.group.GroupControlService;
-import com.cerner.jwala.service.group.GroupJvmControlService;
-import com.cerner.jwala.service.group.GroupService;
-import com.cerner.jwala.service.group.GroupWebServerControlService;
+import com.cerner.jwala.service.group.*;
 import com.cerner.jwala.service.jvm.JvmService;
 import com.cerner.jwala.service.resource.ResourceService;
 import com.cerner.jwala.service.resource.impl.ResourceGeneratorType;
@@ -60,8 +57,13 @@ import java.util.concurrent.*;
 public class GroupServiceRestImpl implements GroupServiceRest {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(GroupServiceRestImpl.class);
+
     @Autowired
     private JvmServiceRest jvmServiceRest;
+
+    @Autowired
+    private GroupStateNotificationService groupStateNotificationService;
+
     private final GroupService groupService;
     private final ResourceService resourceService;
     private final ExecutorService executorService;
@@ -992,4 +994,15 @@ public class GroupServiceRestImpl implements GroupServiceRest {
     public Response getAllHosts() {
         return ResponseBuilder.ok(groupService.getAllHosts());
     }
+
+    @Override
+    public Response getGroupState(final String groupName) {
+        return ResponseBuilder.ok(groupStateNotificationService.getGroupState(groupName));
+    }
+
+    @Override
+    public Response getGroupStates() {
+        return ResponseBuilder.ok(groupStateNotificationService.getGroupStates());
+    }
+
 }


### PR DESCRIPTION
- Fix JVM not deleting when in new state in group operation page
- Fix JVM and web server dialog box not closing and refreshing the table when ok is clicked
- Wrote additional tests for new status with hard delete option
- Make sure that the JQuery selector that removes the JVM and web server from the group operations table only removes the deleted JVM or web server
- Make delete buttons only accessible by admin users