### PR TITLE
Throwing exception for non-new State upon renaming web-server

### DIFF
--- a/jwala-services/src/main/java/com/cerner/jwala/service/webserver/impl/WebServerServiceImpl.java
+++ b/jwala-services/src/main/java/com/cerner/jwala/service/webserver/impl/WebServerServiceImpl.java
@@ -139,9 +139,10 @@ public class WebServerServiceImpl implements WebServerService {
                                      final User anUpdatingUser) {
         anUpdateWebServerCommand.validate();
 
-        WebServer originalWebServer=getWebServer(anUpdateWebServerCommand.getId());
-        if(!anUpdateWebServerCommand.getNewName().equalsIgnoreCase(originalWebServer.getName())&& !anUpdateWebServerCommand.getState().toStateLabel().equals(WebServerReachableState.WS_NEW.toStateLabel())){
-            throw new WebServerServiceException("Web Server "+originalWebServer.getName()+" is in "+originalWebServer.getState().toStateLabel()+" state, can only rename new web servers");
+        WebServer originalWebServer = getWebServer(anUpdateWebServerCommand.getId());
+        if (!anUpdateWebServerCommand.getNewName().equalsIgnoreCase(originalWebServer.getName()) && !WebServerReachableState.WS_NEW.equals(originalWebServer.getState())) {
+            throw new WebServerServiceException(MessageFormat.format("Web Server {0} is in {1} state, can only rename new web servers",
+                    originalWebServer.getName(), originalWebServer.getState().toStateLabel()));
         }
 
 

--- a/jwala-services/src/main/java/com/cerner/jwala/service/webserver/impl/WebServerServiceImpl.java
+++ b/jwala-services/src/main/java/com/cerner/jwala/service/webserver/impl/WebServerServiceImpl.java
@@ -139,6 +139,12 @@ public class WebServerServiceImpl implements WebServerService {
                                      final User anUpdatingUser) {
         anUpdateWebServerCommand.validate();
 
+        WebServer originalWebServer=getWebServer(anUpdateWebServerCommand.getId());
+        if(!anUpdateWebServerCommand.getNewName().equalsIgnoreCase(originalWebServer.getName())&& !anUpdateWebServerCommand.getState().toStateLabel().equals(WebServerReachableState.WS_NEW.toStateLabel())){
+            throw new WebServerServiceException("Web Server "+originalWebServer.getName()+" is in "+originalWebServer.getState().toStateLabel()+" state, can only rename new web servers");
+        }
+
+
         final List<Group> groups = new LinkedList<>();
         for (Identifier<Group> id : anUpdateWebServerCommand.getNewGroupIds()) {
             groups.add(new Group(id, null));


### PR DESCRIPTION
The issue is similar to the issue in JVMs, the web server can be renamed while its running, thus after renaming, and issuing a stop command, it cannot be stopped. Thus a condition which allows web server to be renamed only in new state is added.

Before you contribute, please review these guidelines to help ensure a smooth process for everyone.

Thanks.

* Read [how to properly contribute to open source projects on Github][1].
* Fork the project.
* Use a feature branch.
* Write [good commit messages][2].
* Use the same coding conventions as the rest of the project.
* Commit locally and push to your fork until you are happy with your contribution.
* Make sure to add tests and verify all the tests are passing when merging upstream.
* Add an entry to the [Changelog][3] accordingly.
* Please add your name to the [CONTRIBUTORS.md][7] file. Adding your name to the [CONTRIBUTORS.md][7] file signifies agreement to all rights and reservations provided by the [License][4].
* [Squash related commits together][5].
* Open a [pull request][6].
* The pull request will be reviewed by the community and merged by the project committers.

[1]: http://gun.io/blog/how-to-github-fork-branch-and-pull-request
[2]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[3]: ./CHANGELOG.md
[4]: ./LICENSE
[5]: http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html
[6]: https://help.github.com/articles/using-pull-requests
[7]: ./CONTRIBUTORS.md
