### PR TITLE
notify the UI that a web server was generated 

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-buildVersion=0.0.192
+buildVersion=0.0.193-SNAPSHOT
 
 #daemon should be false for CI builds
 org.gradle.daemon=false

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-buildVersion=0.0.192-SNAPSHOT
+buildVersion=0.0.192
 
 #daemon should be false for CI builds
 org.gradle.daemon=false

--- a/jwala-services/src/main/java/com/cerner/jwala/service/configuration/service/AemServiceConfiguration.java
+++ b/jwala-services/src/main/java/com/cerner/jwala/service/configuration/service/AemServiceConfiguration.java
@@ -206,9 +206,7 @@ public class AemServiceConfiguration {
                 resourceService,
                 inMemoryStateManagerService,
                 templatePath,
-                binaryDistributionLockManager,
-                topicServerStates,
-                messagingTemplate);
+                binaryDistributionLockManager);
     }
 
     @Bean

--- a/jwala-services/src/main/java/com/cerner/jwala/service/configuration/service/AemServiceConfiguration.java
+++ b/jwala-services/src/main/java/com/cerner/jwala/service/configuration/service/AemServiceConfiguration.java
@@ -97,23 +97,23 @@ import java.util.concurrent.ThreadPoolExecutor;
 @EnableAsync
 @EnableScheduling
 @ComponentScan({"com.cerner.jwala.service.webserver.component",
-                "com.cerner.jwala.service.state",
-                "com.cerner.jwala.service.spring.component",
-                "com.cerner.jwala.commandprocessor.jsch.impl.spring.component",
-                "com.cerner.jwala.service.group.impl.spring.component",
-                "com.cerner.jwala.service.jvm.impl.spring.component",
-                "com.cerner.jwala.service.impl.spring.component",
-                "com.cerner.jwala.service.resource.impl",
-                "com.cerner.jwala.common",
-                "com.cerner.jwala.service.impl",
-                "com.cerner.jwala.service.media.impl",
-                "com.cerner.jwala.common.jsch.impl",
-                "com.cerner.jwala.service.jvm.impl",
-                "com.cerner.jwala.service.jvm.operation.impl",
-                "com.cerner.jwala.control.jvm.command",
-                "com.cerner.jwala.control.webserver.command",
-                "com.cerner.jwala.commandprocessor.impl.jsch",
-                "com.cerner.jwala.control.command.common"})
+        "com.cerner.jwala.service.state",
+        "com.cerner.jwala.service.spring.component",
+        "com.cerner.jwala.commandprocessor.jsch.impl.spring.component",
+        "com.cerner.jwala.service.group.impl.spring.component",
+        "com.cerner.jwala.service.jvm.impl.spring.component",
+        "com.cerner.jwala.service.impl.spring.component",
+        "com.cerner.jwala.service.resource.impl",
+        "com.cerner.jwala.common",
+        "com.cerner.jwala.service.impl",
+        "com.cerner.jwala.service.media.impl",
+        "com.cerner.jwala.common.jsch.impl",
+        "com.cerner.jwala.service.jvm.impl",
+        "com.cerner.jwala.service.jvm.operation.impl",
+        "com.cerner.jwala.control.jvm.command",
+        "com.cerner.jwala.control.webserver.command",
+        "com.cerner.jwala.commandprocessor.impl.jsch",
+        "com.cerner.jwala.control.command.common"})
 public class AemServiceConfiguration {
 
     @Autowired
@@ -159,7 +159,7 @@ public class AemServiceConfiguration {
     @Bean
     public GroupService getGroupService(final HistoryFacadeService historyFacadeService) {
         return new GroupServiceImpl(aemPersistenceServiceConfiguration.getGroupPersistenceService(),
-                                    aemPersistenceServiceConfiguration.getApplicationPersistenceService(),
+                aemPersistenceServiceConfiguration.getApplicationPersistenceService(),
                 resourceService
         );
     }
@@ -191,21 +191,24 @@ public class AemServiceConfiguration {
                                                             final ClientFactoryHelper clientFactoryHelper,
                                                             final HistoryFacadeService historyFacadeService) {
         return new BalancerManagerServiceImpl(groupService, applicationService, webServerService, jvmService, clientFactoryHelper,
-                                              new BalancerManagerHtmlParser(), new BalancerManagerXmlParser(jvmService),
-                                              new BalancerManagerHttpClient(), historyFacadeService);
+                new BalancerManagerHtmlParser(), new BalancerManagerXmlParser(jvmService),
+                new BalancerManagerHttpClient(), historyFacadeService);
     }
 
     @Bean(name = "webServerService")
     public WebServerService getWebServerService(final ResourceService resourceService,
                                                 @Qualifier("webServerInMemoryStateManagerService")
                                                 final InMemoryStateManagerService<Identifier<WebServer>, WebServerReachableState> inMemoryStateManagerService,
-                                                @Value("${paths.resource-templates:../data/templates}") final String templatePath) {
+                                                @Value("${paths.resource-templates:../data/templates}") final String templatePath,
+                                                @Value("${spring.messaging.topic.serverStates:/topic/server-states}") final String topicServerStates) {
         return new WebServerServiceImpl(
                 aemPersistenceServiceConfiguration.getWebServerPersistenceService(),
                 resourceService,
                 inMemoryStateManagerService,
                 templatePath,
-                binaryDistributionLockManager);
+                binaryDistributionLockManager,
+                topicServerStates,
+                messagingTemplate);
     }
 
     @Bean
@@ -232,8 +235,8 @@ public class AemServiceConfiguration {
 
     @Bean(name = "jvmControlService")
     public JvmControlService getJvmControlService(
-                                                  final JvmStateService jvmStateService,
-                                                  final HistoryFacadeService historyFacadeService) {
+            final JvmStateService jvmStateService,
+            final HistoryFacadeService historyFacadeService) {
         return new JvmControlServiceImpl(
                 aemPersistenceServiceConfiguration.getJvmPersistenceService(),
                 jvmStateService,
@@ -412,7 +415,7 @@ public class AemServiceConfiguration {
     }
 
     @Bean
-    public ApplicationContextListener getApplicationContextListener(){
+    public ApplicationContextListener getApplicationContextListener() {
         return new ApplicationContextListener();
     }
 }

--- a/jwala-services/src/main/java/com/cerner/jwala/service/webserver/component/WebServerStateSetterWorker.java
+++ b/jwala-services/src/main/java/com/cerner/jwala/service/webserver/component/WebServerStateSetterWorker.java
@@ -60,7 +60,8 @@ public class WebServerStateSetterWorker {
 
     public WebServerStateSetterWorker(@Qualifier("webServerInMemoryStateManagerService")
                                       final InMemoryStateManagerService<Identifier<WebServer>, WebServerReachableState> inMemoryStateManagerService,
-                                      final WebServerService webServerService, final MessagingService messagingService,
+                                      final WebServerService webServerService,
+                                      final MessagingService messagingService,
                                       final GroupStateNotificationService groupStateNotificationService,
                                       @Qualifier("httpRequestFactory")
                                       final HttpComponentsClientHttpRequestFactory httpRequestFactory) {

--- a/jwala-services/src/main/java/com/cerner/jwala/service/webserver/impl/WebServerServiceImpl.java
+++ b/jwala-services/src/main/java/com/cerner/jwala/service/webserver/impl/WebServerServiceImpl.java
@@ -139,9 +139,10 @@ public class WebServerServiceImpl implements WebServerService {
                                      final User anUpdatingUser) {
         anUpdateWebServerCommand.validate();
 
-        WebServer originalWebServer=getWebServer(anUpdateWebServerCommand.getId());
-        if(!anUpdateWebServerCommand.getNewName().equalsIgnoreCase(originalWebServer.getName())&& !anUpdateWebServerCommand.getState().toStateLabel().equals(WebServerReachableState.WS_NEW.toStateLabel())){
-            throw new WebServerServiceException("Web Server "+originalWebServer.getName()+" is in "+originalWebServer.getState().toStateLabel()+" state, can only rename new web servers");
+        WebServer originalWebServer = getWebServer(anUpdateWebServerCommand.getId());
+        if (!anUpdateWebServerCommand.getNewName().equalsIgnoreCase(originalWebServer.getName()) && !WebServerReachableState.WS_NEW.equals(originalWebServer.getState())) {
+            throw new WebServerServiceException(MessageFormat.format("Web Server {0} is in {1} state, can only rename new web servers",
+                    originalWebServer.getName(), originalWebServer.getState().toStateLabel()));
         }
 
 

--- a/jwala-services/src/main/java/com/cerner/jwala/service/webserver/impl/WebServerServiceImpl.java
+++ b/jwala-services/src/main/java/com/cerner/jwala/service/webserver/impl/WebServerServiceImpl.java
@@ -139,6 +139,12 @@ public class WebServerServiceImpl implements WebServerService {
                                      final User anUpdatingUser) {
         anUpdateWebServerCommand.validate();
 
+        WebServer originalWebServer=getWebServer(anUpdateWebServerCommand.getId());
+        if(!anUpdateWebServerCommand.getNewName().equalsIgnoreCase(originalWebServer.getName())&& !anUpdateWebServerCommand.getState().toStateLabel().equals(WebServerReachableState.WS_NEW.toStateLabel())){
+            throw new WebServerServiceException("Web Server "+originalWebServer.getName()+" is in "+originalWebServer.getState().toStateLabel()+" state, can only rename new web servers");
+        }
+
+
         final List<Group> groups = new LinkedList<>();
         for (Identifier<Group> id : anUpdateWebServerCommand.getNewGroupIds()) {
             groups.add(new Group(id, null));

--- a/jwala-services/src/main/java/com/cerner/jwala/service/webserver/impl/WebServerServiceImpl.java
+++ b/jwala-services/src/main/java/com/cerner/jwala/service/webserver/impl/WebServerServiceImpl.java
@@ -6,6 +6,8 @@ import com.cerner.jwala.common.domain.model.id.Identifier;
 import com.cerner.jwala.common.domain.model.resource.ResourceGroup;
 import com.cerner.jwala.common.domain.model.resource.ResourceIdentifier;
 import com.cerner.jwala.common.domain.model.resource.ResourceTemplateMetaData;
+import com.cerner.jwala.common.domain.model.state.CurrentState;
+import com.cerner.jwala.common.domain.model.state.StateType;
 import com.cerner.jwala.common.domain.model.user.User;
 import com.cerner.jwala.common.domain.model.webserver.WebServer;
 import com.cerner.jwala.common.domain.model.webserver.WebServerControlOperation;
@@ -27,10 +29,12 @@ import com.cerner.jwala.service.webserver.WebServerService;
 import com.cerner.jwala.service.webserver.exception.WebServerServiceException;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
+import org.joda.time.DateTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -56,6 +60,10 @@ public class WebServerServiceImpl implements WebServerService {
 
     private final BinaryDistributionLockManager binaryDistributionLockManager;
 
+    private String topicServerStates;
+
+    private final SimpMessagingTemplate messagingTemplate;
+
     @Autowired
     private WebServerControlService webServerControlService;
 
@@ -64,12 +72,16 @@ public class WebServerServiceImpl implements WebServerService {
                                 @Qualifier("webServerInMemoryStateManagerService")
                                 final InMemoryStateManagerService<Identifier<WebServer>, WebServerReachableState> inMemoryStateManagerService,
                                 final String templatePath,
-                                final BinaryDistributionLockManager binaryDistributionLockManager) {
+                                final BinaryDistributionLockManager binaryDistributionLockManager,
+                                final String topicServerStates,
+                                final SimpMessagingTemplate messagingTemplate) {
         this.webServerPersistenceService = webServerPersistenceService;
         this.inMemoryStateManagerService = inMemoryStateManagerService;
         this.templatePath = templatePath;
         this.resourceService = resourceService;
         this.binaryDistributionLockManager = binaryDistributionLockManager;
+        this.topicServerStates = topicServerStates;
+        this.messagingTemplate = messagingTemplate;
         initInMemoryStateService();
     }
 
@@ -208,6 +220,7 @@ public class WebServerServiceImpl implements WebServerService {
     public void updateState(final Identifier<WebServer> id, final WebServerReachableState state, final String errorStatus) {
         webServerPersistenceService.updateState(id, state, errorStatus);
         inMemoryStateManagerService.put(id, state);
+        messagingTemplate.convertAndSend(topicServerStates, new CurrentState<>(id, state, DateTime.now(), StateType.WEB_SERVER));
     }
 
     @Override

--- a/jwala-services/src/main/java/com/cerner/jwala/service/webserver/impl/WebServerServiceImpl.java
+++ b/jwala-services/src/main/java/com/cerner/jwala/service/webserver/impl/WebServerServiceImpl.java
@@ -6,6 +6,8 @@ import com.cerner.jwala.common.domain.model.id.Identifier;
 import com.cerner.jwala.common.domain.model.resource.ResourceGroup;
 import com.cerner.jwala.common.domain.model.resource.ResourceIdentifier;
 import com.cerner.jwala.common.domain.model.resource.ResourceTemplateMetaData;
+import com.cerner.jwala.common.domain.model.state.CurrentState;
+import com.cerner.jwala.common.domain.model.state.StateType;
 import com.cerner.jwala.common.domain.model.user.User;
 import com.cerner.jwala.common.domain.model.webserver.WebServer;
 import com.cerner.jwala.common.domain.model.webserver.WebServerControlOperation;
@@ -27,10 +29,12 @@ import com.cerner.jwala.service.webserver.WebServerService;
 import com.cerner.jwala.service.webserver.exception.WebServerServiceException;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
+import org.joda.time.DateTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -56,6 +60,10 @@ public class WebServerServiceImpl implements WebServerService {
 
     private final BinaryDistributionLockManager binaryDistributionLockManager;
 
+    private String topicServerStates;
+
+    private final SimpMessagingTemplate messagingTemplate;
+
     @Autowired
     private WebServerControlService webServerControlService;
 
@@ -64,12 +72,16 @@ public class WebServerServiceImpl implements WebServerService {
                                 @Qualifier("webServerInMemoryStateManagerService")
                                 final InMemoryStateManagerService<Identifier<WebServer>, WebServerReachableState> inMemoryStateManagerService,
                                 final String templatePath,
-                                final BinaryDistributionLockManager binaryDistributionLockManager) {
+                                final BinaryDistributionLockManager binaryDistributionLockManager,
+                                final String topicServerStates,
+                                final SimpMessagingTemplate messagingTemplate) {
         this.webServerPersistenceService = webServerPersistenceService;
         this.inMemoryStateManagerService = inMemoryStateManagerService;
         this.templatePath = templatePath;
         this.resourceService = resourceService;
         this.binaryDistributionLockManager = binaryDistributionLockManager;
+        this.topicServerStates = topicServerStates;
+        this.messagingTemplate = messagingTemplate;
         initInMemoryStateService();
     }
 
@@ -215,6 +227,7 @@ public class WebServerServiceImpl implements WebServerService {
     public void updateState(final Identifier<WebServer> id, final WebServerReachableState state, final String errorStatus) {
         webServerPersistenceService.updateState(id, state, errorStatus);
         inMemoryStateManagerService.put(id, state);
+        messagingTemplate.convertAndSend(topicServerStates, new CurrentState<>(id, state, DateTime.now(), StateType.WEB_SERVER));
     }
 
     @Override

--- a/jwala-services/src/main/java/com/cerner/jwala/service/webserver/impl/WebServerServiceImpl.java
+++ b/jwala-services/src/main/java/com/cerner/jwala/service/webserver/impl/WebServerServiceImpl.java
@@ -6,8 +6,6 @@ import com.cerner.jwala.common.domain.model.id.Identifier;
 import com.cerner.jwala.common.domain.model.resource.ResourceGroup;
 import com.cerner.jwala.common.domain.model.resource.ResourceIdentifier;
 import com.cerner.jwala.common.domain.model.resource.ResourceTemplateMetaData;
-import com.cerner.jwala.common.domain.model.state.CurrentState;
-import com.cerner.jwala.common.domain.model.state.StateType;
 import com.cerner.jwala.common.domain.model.user.User;
 import com.cerner.jwala.common.domain.model.webserver.WebServer;
 import com.cerner.jwala.common.domain.model.webserver.WebServerControlOperation;
@@ -29,12 +27,10 @@ import com.cerner.jwala.service.webserver.WebServerService;
 import com.cerner.jwala.service.webserver.exception.WebServerServiceException;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
-import org.joda.time.DateTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -60,10 +56,6 @@ public class WebServerServiceImpl implements WebServerService {
 
     private final BinaryDistributionLockManager binaryDistributionLockManager;
 
-    private String topicServerStates;
-
-    private final SimpMessagingTemplate messagingTemplate;
-
     @Autowired
     private WebServerControlService webServerControlService;
 
@@ -72,16 +64,12 @@ public class WebServerServiceImpl implements WebServerService {
                                 @Qualifier("webServerInMemoryStateManagerService")
                                 final InMemoryStateManagerService<Identifier<WebServer>, WebServerReachableState> inMemoryStateManagerService,
                                 final String templatePath,
-                                final BinaryDistributionLockManager binaryDistributionLockManager,
-                                final String topicServerStates,
-                                final SimpMessagingTemplate messagingTemplate) {
+                                final BinaryDistributionLockManager binaryDistributionLockManager) {
         this.webServerPersistenceService = webServerPersistenceService;
         this.inMemoryStateManagerService = inMemoryStateManagerService;
         this.templatePath = templatePath;
         this.resourceService = resourceService;
         this.binaryDistributionLockManager = binaryDistributionLockManager;
-        this.topicServerStates = topicServerStates;
-        this.messagingTemplate = messagingTemplate;
         initInMemoryStateService();
     }
 
@@ -220,7 +208,6 @@ public class WebServerServiceImpl implements WebServerService {
     public void updateState(final Identifier<WebServer> id, final WebServerReachableState state, final String errorStatus) {
         webServerPersistenceService.updateState(id, state, errorStatus);
         inMemoryStateManagerService.put(id, state);
-        messagingTemplate.convertAndSend(topicServerStates, new CurrentState<>(id, state, DateTime.now(), StateType.WEB_SERVER));
     }
 
     @Override

--- a/jwala-services/src/test/java/com/cerner/jwala/service/webserver/impl/WebServerServiceImplIntegrationTest.java
+++ b/jwala-services/src/test/java/com/cerner/jwala/service/webserver/impl/WebServerServiceImplIntegrationTest.java
@@ -85,7 +85,7 @@ public class WebServerServiceImplIntegrationTest {
 
     @Before
     public void setup() {
-        webServerService = new WebServerServiceImpl(webServerPersistenceService, resourceService, inMemService, "d:/jwala/app/data/types", binaryDistributionLockManager, "test/states", mockMessageTemplate);
+        webServerService = new WebServerServiceImpl(webServerPersistenceService, resourceService, inMemService, "d:/jwala/app/data/types", binaryDistributionLockManager);
     }
 
     @Test(expected = NotFoundException.class)

--- a/jwala-services/src/test/java/com/cerner/jwala/service/webserver/impl/WebServerServiceImplIntegrationTest.java
+++ b/jwala-services/src/test/java/com/cerner/jwala/service/webserver/impl/WebServerServiceImplIntegrationTest.java
@@ -24,12 +24,15 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.test.annotation.IfProfileValue;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.support.AnnotationConfigContextLoader;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
 import org.springframework.transaction.annotation.Transactional;
+
+import static org.mockito.Mockito.mock;
 
 @ContextConfiguration(loader = AnnotationConfigContextLoader.class, classes = {
         WebServerServiceImplIntegrationTest.CommonConfiguration.class,
@@ -45,6 +48,7 @@ public class WebServerServiceImplIntegrationTest {
     @Configuration
     static class CommonConfiguration {
 
+        static final SimpMessagingTemplate mockMessageTemplate = mock(SimpMessagingTemplate.class);
         @Bean
         public WebServerPersistenceService getWebServerPersistenceService() {
             return new WebServerPersistenceServiceImpl(getGroupCrudService(), getWebServerCrudService());
@@ -60,6 +64,9 @@ public class WebServerServiceImplIntegrationTest {
             return new GroupCrudServiceImpl();
         }
 
+        @Bean
+        public SimpMessagingTemplate getMessageTemplate() { return mockMessageTemplate; }
+
     }
 
     @Autowired
@@ -73,9 +80,12 @@ public class WebServerServiceImplIntegrationTest {
     @Autowired
     private BinaryDistributionLockManager binaryDistributionLockManager;
 
+    @Autowired
+    private SimpMessagingTemplate mockMessageTemplate;
+
     @Before
     public void setup() {
-        webServerService = new WebServerServiceImpl(webServerPersistenceService, resourceService, inMemService, "d:/jwala/app/data/types", binaryDistributionLockManager);
+        webServerService = new WebServerServiceImpl(webServerPersistenceService, resourceService, inMemService, "d:/jwala/app/data/types", binaryDistributionLockManager, "test/states", mockMessageTemplate);
     }
 
     @Test(expected = NotFoundException.class)

--- a/jwala-services/src/test/java/com/cerner/jwala/service/webserver/impl/WebServerServiceImplTest.java
+++ b/jwala-services/src/test/java/com/cerner/jwala/service/webserver/impl/WebServerServiceImplTest.java
@@ -9,7 +9,6 @@ import com.cerner.jwala.common.domain.model.resource.ResourceContent;
 import com.cerner.jwala.common.domain.model.resource.ResourceGroup;
 import com.cerner.jwala.common.domain.model.resource.ResourceIdentifier;
 import com.cerner.jwala.common.domain.model.resource.ResourceTemplateMetaData;
-import com.cerner.jwala.common.domain.model.state.CurrentState;
 import com.cerner.jwala.common.domain.model.user.User;
 import com.cerner.jwala.common.domain.model.webserver.WebServer;
 import com.cerner.jwala.common.domain.model.webserver.WebServerReachableState;
@@ -37,7 +36,6 @@ import org.mockito.Matchers;
 import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
-import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.support.AnnotationConfigContextLoader;
@@ -137,7 +135,7 @@ public class WebServerServiceImplTest {
         mockWebServers12.add(mockWebServer2);
 
         reset(Config.mockBinaryDistributionLockManager, Config.mockResourceService, Config.mockWebServerControlService,
-              Config.mockWebServerPersistenceService, Config.mockMessageTemplate);
+              Config.mockWebServerPersistenceService);
     }
 
     @SuppressWarnings("unchecked")
@@ -334,7 +332,6 @@ public class WebServerServiceImplTest {
     public void testUpdateState() {
         wsService.updateState(mockWebServer.getId(), WebServerReachableState.WS_REACHABLE, "");
         verify(Config.mockWebServerPersistenceService).updateState(new Identifier<WebServer>(1L), WebServerReachableState.WS_REACHABLE, "");
-        verify(Config.mockMessageTemplate, times(1)).convertAndSend(anyString(), any(CurrentState.class));
         assertEquals(WebServerReachableState.WS_REACHABLE, Config.inMemService.get(mockWebServer.getId()));
     }
 
@@ -474,8 +471,6 @@ public class WebServerServiceImplTest {
 
         private static BinaryDistributionLockManager mockBinaryDistributionLockManager = mock(BinaryDistributionLockManager.class);
 
-        private static SimpMessagingTemplate mockMessageTemplate = mock(SimpMessagingTemplate.class);
-
         @Bean
         public static WebServerPersistenceService getMockWebServerPersistenceService() {
             return mockWebServerPersistenceService;
@@ -497,11 +492,9 @@ public class WebServerServiceImplTest {
         }
 
         @Bean
-        public SimpMessagingTemplate getMockMessageTemplate() { return mockMessageTemplate; }
-        @Bean
         public WebServerService getWebSereWebServerService() {
             return new WebServerServiceImpl(mockWebServerPersistenceService, mockResourceService, inMemService, "/any",
-                    mockBinaryDistributionLockManager, "test/topics", mockMessageTemplate);
+                    mockBinaryDistributionLockManager);
         }
 
     }

--- a/jwala-webservices/src/main/java/com/cerner/jwala/ws/rest/v1/service/webserver/impl/WebServerServiceRestImpl.java
+++ b/jwala-webservices/src/main/java/com/cerner/jwala/ws/rest/v1/service/webserver/impl/WebServerServiceRestImpl.java
@@ -21,10 +21,10 @@ import com.cerner.jwala.control.AemControl;
 import com.cerner.jwala.exception.CommandFailureException;
 import com.cerner.jwala.persistence.jpa.type.EventType;
 import com.cerner.jwala.service.HistoryFacadeService;
+import com.cerner.jwala.service.MessagingService;
 import com.cerner.jwala.service.binarydistribution.BinaryDistributionLockManager;
 import com.cerner.jwala.service.binarydistribution.BinaryDistributionService;
 import com.cerner.jwala.service.group.GroupService;
-import com.cerner.jwala.service.impl.spring.component.SimpMessagingServiceImpl;
 import com.cerner.jwala.service.resource.ResourceService;
 import com.cerner.jwala.service.webserver.WebServerCommandService;
 import com.cerner.jwala.service.webserver.WebServerControlService;
@@ -62,10 +62,10 @@ public class WebServerServiceRestImpl implements WebServerServiceRest {
     private static final Long DEFAULT_WAIT_TIMEOUT = 30000L;
 
     @Autowired
-    BinaryDistributionLockManager binaryDistributionLockManager;
+    private BinaryDistributionLockManager binaryDistributionLockManager;
 
     @Autowired
-    SimpMessagingServiceImpl simpleMessagingService;
+    private MessagingService simpleMessagingService;
 
     private final WebServerService webServerService;
     private final WebServerControlService webServerControlService;

--- a/jwala-webservices/src/main/java/com/cerner/jwala/ws/rest/v1/service/webserver/impl/WebServerServiceRestImpl.java
+++ b/jwala-webservices/src/main/java/com/cerner/jwala/ws/rest/v1/service/webserver/impl/WebServerServiceRestImpl.java
@@ -8,6 +8,7 @@ import com.cerner.jwala.common.domain.model.resource.ResourceIdentifier;
 import com.cerner.jwala.common.domain.model.webserver.WebServer;
 import com.cerner.jwala.common.domain.model.webserver.WebServerControlOperation;
 import com.cerner.jwala.common.domain.model.webserver.WebServerReachableState;
+import com.cerner.jwala.common.domain.model.webserver.WebServerState;
 import com.cerner.jwala.common.exception.FaultCodeException;
 import com.cerner.jwala.common.exception.InternalErrorException;
 import com.cerner.jwala.common.exec.CommandOutput;
@@ -23,6 +24,7 @@ import com.cerner.jwala.service.HistoryFacadeService;
 import com.cerner.jwala.service.binarydistribution.BinaryDistributionLockManager;
 import com.cerner.jwala.service.binarydistribution.BinaryDistributionService;
 import com.cerner.jwala.service.group.GroupService;
+import com.cerner.jwala.service.impl.spring.component.SimpMessagingServiceImpl;
 import com.cerner.jwala.service.resource.ResourceService;
 import com.cerner.jwala.service.webserver.WebServerCommandService;
 import com.cerner.jwala.service.webserver.WebServerControlService;
@@ -34,6 +36,7 @@ import com.cerner.jwala.ws.rest.v1.response.ResponseBuilder;
 import com.cerner.jwala.ws.rest.v1.service.webserver.WebServerServiceRest;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.joda.time.DateTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -60,6 +63,10 @@ public class WebServerServiceRestImpl implements WebServerServiceRest {
 
     @Autowired
     BinaryDistributionLockManager binaryDistributionLockManager;
+
+    @Autowired
+    SimpMessagingServiceImpl simpleMessagingService;
+
     private final WebServerService webServerService;
     private final WebServerControlService webServerControlService;
     private final WebServerCommandService webServerCommandService;
@@ -232,6 +239,9 @@ public class WebServerServiceRestImpl implements WebServerServiceRest {
             installWebServerService(aUser, new ControlWebServerRequest(webServer.getId(), WebServerControlOperation.INSTALL_SERVICE), webServer);
 
             webServerService.updateState(webServer.getId(), WebServerReachableState.WS_UNREACHABLE, StringUtils.EMPTY);
+
+            simpleMessagingService.send(new WebServerState(webServer.getId(), WebServerReachableState.WS_UNREACHABLE, DateTime.now()));
+
             didSucceed = true;
         } catch (CommandFailureException e) {
             LOGGER.error("Failed for {}", aWebServerName, e);
@@ -444,9 +454,5 @@ public class WebServerServiceRestImpl implements WebServerServiceRest {
             return ResponseBuilder.notOk(Response.Status.INTERNAL_SERVER_ERROR, new FaultCodeException(
                     FaultType.INVALID_TEMPLATE, rte.getMessage()));
         }
-    }
-
-    public void setLockManager(BinaryDistributionLockManager binaryDistributionLockManager) {
-        this.binaryDistributionLockManager = binaryDistributionLockManager;
     }
 }

--- a/jwala-webservices/src/test/java/com/cerner/jwala/ws/rest/v1/service/group/impl/GroupServiceImplDeployTest.java
+++ b/jwala-webservices/src/test/java/com/cerner/jwala/ws/rest/v1/service/group/impl/GroupServiceImplDeployTest.java
@@ -25,8 +25,8 @@ import com.cerner.jwala.service.app.ApplicationService;
 import com.cerner.jwala.service.binarydistribution.BinaryDistributionControlService;
 import com.cerner.jwala.service.binarydistribution.BinaryDistributionLockManager;
 import com.cerner.jwala.service.binarydistribution.BinaryDistributionService;
-import com.cerner.jwala.service.binarydistribution.impl.BinaryDistributionLockManagerImpl;
 import com.cerner.jwala.service.group.*;
+import com.cerner.jwala.service.impl.spring.component.SimpMessagingServiceImpl;
 import com.cerner.jwala.service.jvm.JvmControlService;
 import com.cerner.jwala.service.jvm.JvmService;
 import com.cerner.jwala.service.resource.ResourceService;
@@ -479,6 +479,13 @@ public class GroupServiceImplDeployTest {
         static final BinaryDistributionLockManager mockBinaryDistributionLockManager = mock(BinaryDistributionLockManager.class);
         private static final BinaryDistributionControlService binaryDistributionControlService = mock(BinaryDistributionControlService.class);
         private static final GroupStateNotificationService mockGroupStateNotificationService = mock(GroupStateNotificationService.class);
+        private static final SimpMessagingServiceImpl mockSimpleMessagingService = mock(SimpMessagingServiceImpl.class);
+
+
+        @Bean
+        public SimpMessagingServiceImpl getMockSimpleMessagingService() {
+            return mockSimpleMessagingService;
+        }
 
         @Bean
         public BinaryDistributionControlService getBinaryDistributionControlService(){
@@ -499,9 +506,7 @@ public class GroupServiceImplDeployTest {
 
         @Bean
         WebServerServiceRest getWebServerServiceRest() {
-            WebServerServiceRestImpl webServerServiceRest = new WebServerServiceRestImpl(mockWebServerService, mockWebServerControlService, mock(WebServerCommandService.class), mockResourceService, mockGroupService, binaryDistributionService, mockHistoryService);
-            webServerServiceRest.setLockManager(new BinaryDistributionLockManagerImpl());
-            return webServerServiceRest;
+            return new WebServerServiceRestImpl(mockWebServerService, mockWebServerControlService, mock(WebServerCommandService.class), mockResourceService, mockGroupService, binaryDistributionService, mockHistoryService);
         }
 
         @Bean


### PR DESCRIPTION
After generating a web server from the Operations tab, the state of the web server does not get updated from NEW to STOPPED. This causes problems when trying to start the web server from the UI immediately after generating.

The fix is to send the state update to the UI immediately after completing the web server generation.