### PR TITLE
Check the jvm state first before checking if state is stale

### DIFF
--- a/jwala-services/src/main/java/com/cerner/jwala/service/jvm/impl/spring/component/JvmStateServiceImpl.java
+++ b/jwala-services/src/main/java/com/cerner/jwala/service/jvm/impl/spring/component/JvmStateServiceImpl.java
@@ -102,7 +102,7 @@ public class JvmStateServiceImpl implements JvmStateService {
         }
 
         for (final Jvm jvm : jvms) {
-            if (stateNotInMemory(jvm) || isValidState(jvm) && isStale(jvm) && isFutureNilOrDone(jvm)) {
+            if (stateNotInMemory(jvm) || isValidState(jvm) && isFutureNilOrDone(jvm) && isStale(jvm)) {
                 LOGGER.debug("Pinging JVM {} ...", jvm.getJvmName());
                 PING_FUTURE_MAP.put(jvm.getId(), jvmStateResolverWorker.pingAndUpdateJvmState(jvm, this));
                 LOGGER.debug("Pinged JVM {}", jvm.getJvmName());

--- a/jwala-services/src/main/java/com/cerner/jwala/service/jvm/impl/spring/component/JvmStateServiceImpl.java
+++ b/jwala-services/src/main/java/com/cerner/jwala/service/jvm/impl/spring/component/JvmStateServiceImpl.java
@@ -102,7 +102,7 @@ public class JvmStateServiceImpl implements JvmStateService {
         }
 
         for (final Jvm jvm : jvms) {
-            if (stateNotInMemory(jvm) || isStale(jvm) && isValidState(jvm) && isFutureNilOrDone(jvm)) {
+            if (stateNotInMemory(jvm) || isValidState(jvm) && isStale(jvm) && isFutureNilOrDone(jvm)) {
                 LOGGER.debug("Pinging JVM {} ...", jvm.getJvmName());
                 PING_FUTURE_MAP.put(jvm.getId(), jvmStateResolverWorker.pingAndUpdateJvmState(jvm, this));
                 LOGGER.debug("Pinged JVM {}", jvm.getJvmName());


### PR DESCRIPTION
This prevents unnecessary logging  that the JVM is stale (stopped JVMs are supposed to be inactive so there's no point in checking if their state is stale or not)