### PR TITLE
Refresh group operations page after deleting a JVM or web server

### DIFF
--- a/jwala-integration-test/src/test/java/com/cerner/jwala/ui/selenium/JwalaChromeTestSuite.java
+++ b/jwala-integration-test/src/test/java/com/cerner/jwala/ui/selenium/JwalaChromeTestSuite.java
@@ -10,7 +10,11 @@ import com.cerner.jwala.ui.selenium.testsuite.configuration.group.GroupDeleteTes
 import com.cerner.jwala.ui.selenium.testsuite.configuration.jvm.JvmCreateTest;
 import com.cerner.jwala.ui.selenium.testsuite.configuration.jvm.JvmDeleteTest;
 import com.cerner.jwala.ui.selenium.testsuite.configuration.resources.*;
+import com.cerner.jwala.ui.selenium.testsuite.configuration.webServer.WebServerCreateTest;
+import com.cerner.jwala.ui.selenium.testsuite.configuration.webServer.WebServerDeleteTest;
 import com.cerner.jwala.ui.selenium.testsuite.operations.HistoryTablePopupTest;
+import com.cerner.jwala.ui.selenium.testsuite.operations.JvmOperationsPageDeleteTest;
+import com.cerner.jwala.ui.selenium.testsuite.operations.WebServerOperationsPageDelete;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
@@ -24,10 +28,11 @@ import java.util.concurrent.TimeUnit;
  * Created by Jedd Cuison on 2/22/2017
  */
 @RunWith(Suite.class)
-@Suite.SuiteClasses({PreFlightTest.class, LoginTest.class, GroupCreateTest.class, JvmCreateTest.class, AppCreateTest.class,
-        ResourceTopologyTest.class, UploadResourceTest.class, AddExternalProperty.class, ModifyExternalPropertyResource.class,
-        DeleteExternalProperty.class, HistoryTablePopupTest.class, AppDeleteTest.class, JvmDeleteTest.class, GroupDeleteTest.class,
-        LogoutTest.class})
+@Suite.SuiteClasses({PreFlightTest.class, LoginTest.class, GroupCreateTest.class, JvmCreateTest.class, WebServerCreateTest.class,
+        AppCreateTest.class, ResourceTopologyTest.class, UploadResourceTest.class, AddExternalProperty.class,
+        ModifyExternalPropertyResource.class, DeleteExternalProperty.class, HistoryTablePopupTest.class, AppDeleteTest.class,
+        JvmOperationsPageDeleteTest.class, WebServerOperationsPageDelete.class, WebServerCreateTest.class, WebServerDeleteTest.class,
+        JvmCreateTest.class, JvmDeleteTest.class, GroupDeleteTest.class, LogoutTest.class})
 public class JwalaChromeTestSuite extends TestSuite {
 
     private static final String WEBDRIVER_CHROME_DRIVER = "webdriver.chrome.driver";

--- a/jwala-integration-test/src/test/java/com/cerner/jwala/ui/selenium/JwalaChromeTestSuite.java
+++ b/jwala-integration-test/src/test/java/com/cerner/jwala/ui/selenium/JwalaChromeTestSuite.java
@@ -9,8 +9,8 @@ import com.cerner.jwala.ui.selenium.testsuite.configuration.group.GroupCreateTes
 import com.cerner.jwala.ui.selenium.testsuite.configuration.group.GroupDeleteTest;
 import com.cerner.jwala.ui.selenium.testsuite.configuration.jvm.JvmCreateTest;
 import com.cerner.jwala.ui.selenium.testsuite.configuration.jvm.JvmDeleteTest;
-import com.cerner.jwala.ui.selenium.testsuite.configuration.operations.HistoryTablePopupTest;
 import com.cerner.jwala.ui.selenium.testsuite.configuration.resources.*;
+import com.cerner.jwala.ui.selenium.testsuite.operations.HistoryTablePopupTest;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.runner.RunWith;

--- a/jwala-integration-test/src/test/java/com/cerner/jwala/ui/selenium/testsuite/configuration/webServer/WebServerCreateTest.java
+++ b/jwala-integration-test/src/test/java/com/cerner/jwala/ui/selenium/testsuite/configuration/webServer/WebServerCreateTest.java
@@ -1,0 +1,52 @@
+package com.cerner.jwala.ui.selenium.testsuite.configuration.webServer;
+
+import com.cerner.jwala.ui.selenium.testsuite.JwalaTest;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.Keys;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.WebDriverWait;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Created by Jedd Cuison on 2/28/2017
+ */
+public class WebServerCreateTest extends JwalaTest {
+
+    private static final String GROUP_NAME_1 = "zGroup1-" + CURRENT_TIME_MILLIS;
+    private static final String GROUP_NAME_2 = "zGroup2-" + CURRENT_TIME_MILLIS;
+
+    private static final String WS_NAME = "zWS-" + CURRENT_TIME_MILLIS;
+
+    @Test
+    public void testCreateJvm() throws InterruptedException {
+        clickTab("Configuration");
+        clickTab("Web Servers");
+
+        driver.findElement(By.xpath("//button[span[text()='Add']]")).click();
+
+        // Get the width of the dialog box so we can test if the width changed later after selecting the groups
+        final WebElement jvmDlg = driver.findElement(By.xpath("//div[contains(@class, 'ui-dialog')]"));
+        final int dlgWidth = jvmDlg.getSize().getWidth();
+
+        driver.switchTo().activeElement().sendKeys(WS_NAME);
+        driver.switchTo().activeElement().sendKeys(Keys.TAB);
+        driver.switchTo().activeElement().sendKeys(WS_NAME + "-host");
+        driver.switchTo().activeElement().sendKeys(Keys.TAB);
+        driver.switchTo().activeElement().sendKeys("80");
+        driver.switchTo().activeElement().sendKeys(Keys.TAB);
+        driver.switchTo().activeElement().sendKeys("443");
+        driver.switchTo().activeElement().sendKeys(Keys.TAB);
+        assertEquals("https://" + WS_NAME + "-host:443/apache_pb.png", driver.switchTo().activeElement().getAttribute("value"));
+        driver.switchTo().activeElement().sendKeys(Keys.TAB);
+        driver.findElement(By.xpath("//div[contains(text(), '" + GROUP_NAME_1 + "')]/input")).click();
+        driver.findElement(By.xpath("//div[contains(text(), '" + GROUP_NAME_2 + "')]/input")).click();
+
+        driver.findElement(By.xpath("//button[span[text()='Ok']]")).click();
+        new WebDriverWait(driver, 5)
+                .until(ExpectedConditions.numberOfElementsToBe(By.xpath("//button[text()='" + WS_NAME + "']"), 1));
+    }
+
+}

--- a/jwala-integration-test/src/test/java/com/cerner/jwala/ui/selenium/testsuite/configuration/webServer/WebServerDeleteTest.java
+++ b/jwala-integration-test/src/test/java/com/cerner/jwala/ui/selenium/testsuite/configuration/webServer/WebServerDeleteTest.java
@@ -1,0 +1,27 @@
+package com.cerner.jwala.ui.selenium.testsuite.configuration.webServer;
+
+import com.cerner.jwala.ui.selenium.testsuite.JwalaTest;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.WebDriverWait;
+
+/**
+ * Created by Jedd Cuison on 3/1/2017
+ */
+public class WebServerDeleteTest extends JwalaTest {
+
+    private static final String WS_NAME = "zWS-" + CURRENT_TIME_MILLIS;
+
+    @Test
+    public void testDeleteJvm() throws InterruptedException {
+        clickTab("Configuration");
+        clickTab("Web Servers");
+        driver.findElement(By.xpath("//tr[td[button[text()='" + WS_NAME + "']]]")).click();
+        driver.findElement(By.xpath("//button[span[text()='Delete']]")).click();
+        driver.findElement(By.xpath("//button[span[text()='Yes']]")).click();
+        new WebDriverWait(driver, 5)
+                .until(ExpectedConditions.numberOfElementsToBe(By.xpath("//button[text()='" + WS_NAME + "']"), 0));
+    }
+
+}

--- a/jwala-integration-test/src/test/java/com/cerner/jwala/ui/selenium/testsuite/operations/HistoryTablePopupTest.java
+++ b/jwala-integration-test/src/test/java/com/cerner/jwala/ui/selenium/testsuite/operations/HistoryTablePopupTest.java
@@ -1,4 +1,4 @@
-package com.cerner.jwala.ui.selenium.testsuite.configuration.operations;
+package com.cerner.jwala.ui.selenium.testsuite.operations;
 
 import com.cerner.jwala.ui.selenium.testsuite.JwalaTest;
 import org.junit.Test;

--- a/jwala-integration-test/src/test/java/com/cerner/jwala/ui/selenium/testsuite/operations/JvmOperationsPageDeleteTest.java
+++ b/jwala-integration-test/src/test/java/com/cerner/jwala/ui/selenium/testsuite/operations/JvmOperationsPageDeleteTest.java
@@ -1,0 +1,37 @@
+package com.cerner.jwala.ui.selenium.testsuite.operations;
+
+import com.cerner.jwala.ui.selenium.testsuite.JwalaTest;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.WebDriverWait;
+
+/**
+ * Created by Jedd Cuison on 4/19/2017
+ */
+public class JvmOperationsPageDeleteTest extends JwalaTest {
+
+    private static final String GROUP_NAME_1 = "zGroup1-" + CURRENT_TIME_MILLIS;
+    private static final String JVM_NAME = "zJvm-" + CURRENT_TIME_MILLIS;
+
+    private WebDriverWait webDriverWait = new WebDriverWait(driver, 60);
+
+    @Test
+    public void testDeleteJvm() throws InterruptedException {
+        clickTab("Operations");
+
+        webDriverWait.until(ExpectedConditions.numberOfElementsToBe(By.xpath("//span[text()='Connecting to a web socket...']"), 0));
+        final By openRowBtnLocator = By.xpath("//td[text()='" + GROUP_NAME_1 + "']/preceding-sibling::td");
+        final WebElement openRowBtn = webDriverWait.until(ExpectedConditions.elementToBeClickable(openRowBtnLocator));
+        openRowBtn.click();
+
+        driver.findElement(By.xpath("//tr[td[text()='" + JVM_NAME + "']]/td/div[contains(@class, 'jvm-control-panel-widget')]/button[span[contains(@class, 'ui-icon-trash')]]")).click();
+        driver.findElement(By.xpath("//button[span[text()='Yes']]")).click();
+
+        webDriverWait.until(ExpectedConditions.numberOfElementsToBe(By.xpath("//div[contains(text(), 'successfully deleted')]"), 1));
+        driver.findElement(By.xpath("//button[span[text()='Ok']]")).click();
+        webDriverWait.until(ExpectedConditions.numberOfElementsToBe(By.xpath("//td[text()='" + JVM_NAME + "']"), 0));
+    }
+
+}

--- a/jwala-integration-test/src/test/java/com/cerner/jwala/ui/selenium/testsuite/operations/WebServerOperationsPageDelete.java
+++ b/jwala-integration-test/src/test/java/com/cerner/jwala/ui/selenium/testsuite/operations/WebServerOperationsPageDelete.java
@@ -1,0 +1,38 @@
+package com.cerner.jwala.ui.selenium.testsuite.operations;
+
+import com.cerner.jwala.ui.selenium.testsuite.JwalaTest;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.WebDriverWait;
+
+/**
+ * Created by Jedd Cuison on 4/19/2017
+ */
+public class WebServerOperationsPageDelete extends JwalaTest {
+
+    private static final String GROUP_NAME_1 = "zGroup1-" + CURRENT_TIME_MILLIS;
+    private static final String WS_NAME = "zWS-" + CURRENT_TIME_MILLIS;
+
+    private WebDriverWait webDriverWait = new WebDriverWait(driver, 60);
+
+    @Test
+    public void testDeleteJvm() throws InterruptedException {
+        clickTab("Operations");
+
+        webDriverWait.until(ExpectedConditions.numberOfElementsToBe(By.xpath("//span[text()='Connecting to a web socket...']"), 0));
+        final By openRowBtnLocator = By.xpath("//td[text()='" + GROUP_NAME_1 + "']/preceding-sibling::td");
+        final WebElement openRowBtn = webDriverWait.until(ExpectedConditions.elementToBeClickable(openRowBtnLocator));
+        openRowBtn.click();
+
+        driver.findElement(By.xpath("//tr[td[text()='" + WS_NAME + "']]/td/div[contains(@class, 'web-server-control-panel-widget')]/button[span[contains(@class, 'ui-icon-trash')]]")).click();
+        driver.findElement(By.xpath("//button[span[text()='Yes']]")).click();
+
+        webDriverWait.until(ExpectedConditions.numberOfElementsToBe(By.xpath("//div[contains(text(), 'successfully deleted')]"), 1));
+        driver.findElement(By.xpath("//button[span[text()='Ok']]")).click();
+        webDriverWait.until(ExpectedConditions.numberOfElementsToBe(By.xpath("//td[text()='" + WS_NAME + "']"), 0));
+    }
+
+
+}

--- a/jwala-webapp/src/main/webapp/resources/js/alert.js
+++ b/jwala-webapp/src/main/webapp/resources/js/alert.js
@@ -1,10 +1,10 @@
 /**
  * sources: http://coding.abel.nu/2012/01/jquery-ui-replacement-for-alert/
  */
-$.extend({ alert: function (message, aTitle, aModal) {
+$.extend({ alert: function (message, aTitle, aModal, closeCallback) {
   $("<div></div>").dialog( {
-    buttons: { "Ok": function () { $(this).dialog("close"); } },
-    close: function (event, ui) { $(this).remove(); },
+    buttons: { "Ok": function () { $(this).dialog("close"); closeCallback(); } },
+    close: function (event, ui) { $(this).remove();  closeCallback(); },
     resizable: true,
     title: aTitle === undefined ? "Message" : aTitle,
     modal: aModal === undefined ? true : aModal

--- a/jwala-webapp/src/main/webapp/resources/js/react/group-operations/GroupOperationsDataTable.js
+++ b/jwala-webapp/src/main/webapp/resources/js/react/group-operations/GroupOperationsDataTable.js
@@ -815,12 +815,8 @@ var GroupOperationsDataTable = React.createClass({
     webServerConfirmDeleteCallback: function(data) {
         let self = this;
         webServerService.deleteWebServer(data.id.id, true).then(function(e){
-            // Remove deleted row
-             $("[id*='ws-child-table']").find("td:contains('" + data.name + "')").filter(function() {
-                if ($(this).text() === data.name) {
-                    $(this).parent().remove();
-                }
-            });
+            $.alert("Web server " + data.name + " was successfully deleted. Jwala will need to refresh to display the latest data and recompute the states.",
+                    "Delete Web Server", true, function(){location.reload()});
         }).caught(
             function(e) {
                 self.setState({showDeleteConfirmDialog: false})
@@ -843,12 +839,8 @@ var GroupOperationsDataTable = React.createClass({
     jvmConfirmDeleteCallback: function(data) {
         let self = this;
         jvmService.deleteJvm(data.id.id, true).then(function(e){
-            // Remove deleted row
-            $("[id*='jvm-child-table']").find("td:contains('" + data.jvmName + "')").filter(function() {
-                if ($(this).text() === data.jvmName) {
-                    $(this).parent().remove();
-                }
-            });
+            $.alert("JVM " + data.jvmName + " was successfully deleted. Jwala will need to refresh to display the latest data and recompute the states.",
+                    "Delete JVM", true, function(){location.reload()});
         }).caught(
             function(e) {
                 self.setState({showDeleteConfirmDialog: false})


### PR DESCRIPTION
This fixes the following issues:

- The deleted JVM is still in UI memory and is displayed again when user collapses and opens the row where the deleted JVM belonged to
- Group state and state count is not correct
- Web server section state count is incorrect
- JVM section state count is incorrect

Note: Refreshing the display dynamically would be very difficult without doing a lot of workarounds. The group operations page was written during the time that the team was still learning about React resulting to a complex code and ironically something that goes against some of the principals of React - my bad really. Anyways, the group operations page is really due for a refactoring. Believe it or not the rewrite is WAY less complex and probably due to experience is easier to do and finish. We just need to complete the selenium test cases for the group operations page and some time. 