### PR TITLE
Hot deploy resource

### DIFF
--- a/jwala-common/src/main/java/com/cerner/jwala/common/domain/model/resource/ResourceTemplateMetaData.java
+++ b/jwala-common/src/main/java/com/cerner/jwala/common/domain/model/resource/ResourceTemplateMetaData.java
@@ -24,6 +24,7 @@ public class ResourceTemplateMetaData {
     private final Entity entity;
     private boolean unpack;
     private boolean overwrite;
+    private boolean hotDeploy;
 
     @JsonIgnore
     private String jsonData;
@@ -35,7 +36,8 @@ public class ResourceTemplateMetaData {
                                     @JsonProperty("deployPath") final String deployPath,
                                     @JsonProperty("entity") final Entity entity,
                                     @JsonProperty("unpack") final Boolean unpack,
-                                    @JsonProperty("overwrite") Boolean overwrite) {
+                                    @JsonProperty("overwrite") Boolean overwrite,
+                                    @JsonProperty("hotDeploy") Boolean hotDeploy) {
         this.templateName = templateName;
         this.contentType = contentType;
         this.deployFileName = deployFileName;
@@ -43,6 +45,7 @@ public class ResourceTemplateMetaData {
         this.entity = entity;
         this.unpack = unpack == null ? false : unpack;
         this.overwrite = overwrite == null ? true : overwrite;
+        this.hotDeploy = hotDeploy == null ? false : hotDeploy;
     }
 
     public String getTemplateName() {
@@ -81,6 +84,10 @@ public class ResourceTemplateMetaData {
         this.jsonData = jsonData;
     }
 
+    public boolean isHotDeploy() {
+        return hotDeploy;
+    }
+
     @Override
     public String toString() {
         return "ResourceTemplateMetaData{" +
@@ -91,6 +98,7 @@ public class ResourceTemplateMetaData {
                 ", entity=" + entity +
                 ", unpack=" + unpack +
                 ", overwrite=" + overwrite +
+                ", hotDeploy=" + hotDeploy +
                 '}';
     }
 }

--- a/jwala-common/src/test/java/com/cerner/jwala/common/domain/model/ResourceTemplateMetaDataTest.java
+++ b/jwala-common/src/test/java/com/cerner/jwala/common/domain/model/ResourceTemplateMetaDataTest.java
@@ -33,7 +33,7 @@ public class ResourceTemplateMetaDataTest {
     private static final String EXPECTED_META_DATA_STR = "ResourceTemplateMetaData{templateName='SetenvBatTemplate.tpl', " +
             "contentType=text/plain, deployFileName='setenv.bat', deployPath='${vars.'remote.paths.instances'}/${jvm.jvmName}/bin', " +
             "entity=Entity{type='GROUPED_JVMS', group='HEALTH CHECK 4.0', target='HEALTH CHECK 4.0', parentName='null', deployToJvms=true}, " +
-            "unpack=false, overwrite=true}";
+            "unpack=false, overwrite=true, hotDeploy=false}";
 
     @Test
     public void testCreateMetaData() throws IOException {

--- a/jwala-services/src/main/java/com/cerner/jwala/service/app/impl/ApplicationServiceImpl.java
+++ b/jwala-services/src/main/java/com/cerner/jwala/service/app/impl/ApplicationServiceImpl.java
@@ -228,10 +228,10 @@ public class ApplicationServiceImpl implements ApplicationService {
     private void checkJvmStateBeforeDeploy(Jvm jvm, ResourceIdentifier resourceIdentifier) {
         try {
             String metaDataStr = resourceService.getResourceContent(resourceIdentifier).getMetaData();
-            boolean hotDeploy = resourceService.getMetaData(metaDataStr).isHotDeploy();
+            boolean hotDeploy = resourceService.getTokenizedMetaData(resourceIdentifier.resourceName, jvm, metaDataStr).isHotDeploy();
             if (jvm.getState().isStartedState()) {
                 if (hotDeploy) {
-                    LOGGER.info("JVM {} is started, but resource {} is configured with hotDeploy=true. Continuing with deploy ...");
+                    LOGGER.info("JVM {} is started, but resource {} is configured with hotDeploy=true. Continuing with deploy ...", jvm.getJvmName(), resourceIdentifier.resourceName);
                 } else {
                     String deployMsg = MessageFormat.format("The JVM {0} must be stopped or the resource {1} must be configured with hotDeploy=true before the resource can be deployed", jvm.getJvmName(), resourceIdentifier.resourceName);
                     LOGGER.error(deployMsg);
@@ -534,7 +534,7 @@ public class ApplicationServiceImpl implements ApplicationService {
         }
     }
 
-    protected Set<String> getWebAppOnlyResources(final Group group, String appName) {
+    private Set<String> getWebAppOnlyResources(final Group group, String appName) {
         final String groupName = group.getName();
         final Set<String> resourceSet = new HashSet<>();
         List<String> resourceTemplates = groupPersistenceService.getGroupAppsResourceTemplateNames(groupName, appName);
@@ -650,12 +650,4 @@ public class ApplicationServiceImpl implements ApplicationService {
         }
     }
 
-    public BinaryDistributionLockManager getLockManager() {
-        return binaryDistributionLockManager;
-    }
-
-    public ApplicationServiceImpl setLockManager(BinaryDistributionLockManager binaryDistributionLockManager) {
-        this.binaryDistributionLockManager = binaryDistributionLockManager;
-        return this;
-    }
 }

--- a/jwala-services/src/main/java/com/cerner/jwala/service/app/impl/ApplicationServiceImpl.java
+++ b/jwala-services/src/main/java/com/cerner/jwala/service/app/impl/ApplicationServiceImpl.java
@@ -229,15 +229,12 @@ public class ApplicationServiceImpl implements ApplicationService {
         try {
             String metaDataStr = resourceService.getResourceContent(resourceIdentifier).getMetaData();
             boolean hotDeploy = resourceService.getTokenizedMetaData(resourceIdentifier.resourceName, jvm, metaDataStr).isHotDeploy();
-            if (jvm.getState().isStartedState()) {
-                if (hotDeploy) {
-                    LOGGER.info("JVM {} is started, but resource {} is configured with hotDeploy=true. Continuing with deploy ...", jvm.getJvmName(), resourceIdentifier.resourceName);
-                } else {
-                    String deployMsg = MessageFormat.format("The JVM {0} must be stopped or the resource {1} must be configured with hotDeploy=true before the resource can be deployed", jvm.getJvmName(), resourceIdentifier.resourceName);
-                    LOGGER.error(deployMsg);
-                    throw new InternalErrorException(FaultType.REMOTE_COMMAND_FAILURE, deployMsg);
-                }
+            if (jvm.getState().isStartedState() && !hotDeploy) {
+                String deployMsg = MessageFormat.format("The JVM {0} must be stopped or the resource {1} must be configured with hotDeploy=true before the resource can be deployed", jvm.getJvmName(), resourceIdentifier.resourceName);
+                LOGGER.error(deployMsg);
+                throw new InternalErrorException(FaultType.REMOTE_COMMAND_FAILURE, deployMsg);
             }
+            LOGGER.info("JVM {} is started, but resource {} is configured with hotDeploy=true. Continuing with deploy ...", jvm.getJvmName(), resourceIdentifier.resourceName);
         } catch (IOException e) {
             String errMsg = MessageFormat.format("Failed to parse the meta data of resource {0} for JVM {1}", resourceIdentifier.resourceName, jvm.getJvmName());
             LOGGER.error(errMsg, e);

--- a/jwala-services/src/main/java/com/cerner/jwala/service/app/impl/ApplicationServiceImpl.java
+++ b/jwala-services/src/main/java/com/cerner/jwala/service/app/impl/ApplicationServiceImpl.java
@@ -151,7 +151,8 @@ public class ApplicationServiceImpl implements ApplicationService {
                         originalMetaData.getDeployPath(),
                         originalMetaData.getEntity(),
                         updateApplicationRequest.isUnpackWar(),
-                        originalMetaData.isOverwrite());
+                        originalMetaData.isOverwrite(),
+                        originalMetaData.isHotDeploy());
                 String updateJsonMetaData = new ObjectMapper().writerWithDefaultPrettyPrinter().writeValueAsString(updateMetaData);
                 groupPersistenceService.updateGroupAppResourceMetaData(application.getGroup().getName(), appName, appWarName, updateJsonMetaData);
             } catch (JsonGenerationException e) {

--- a/jwala-services/src/main/java/com/cerner/jwala/service/app/impl/ApplicationServiceImpl.java
+++ b/jwala-services/src/main/java/com/cerner/jwala/service/app/impl/ApplicationServiceImpl.java
@@ -429,7 +429,7 @@ public class ApplicationServiceImpl implements ApplicationService {
 
                     if (commandOutput.getReturnCode().wasSuccessful()) {
                         LOGGER.debug("unpacked directory found at {}, backing it up", zipDestinationOption);
-                        commandOutput = distributionControlService.backupFile(host, zipDestinationOption);
+                        commandOutput = distributionControlService.backupFileWithMove(host, zipDestinationOption);
 
                         if (commandOutput.getReturnCode().wasSuccessful()) {
                             LOGGER.debug("successful back up of {}", zipDestinationOption);

--- a/jwala-services/src/main/java/com/cerner/jwala/service/binarydistribution/BinaryDistributionControlService.java
+++ b/jwala-services/src/main/java/com/cerner/jwala/service/binarydistribution/BinaryDistributionControlService.java
@@ -71,16 +71,16 @@ public interface BinaryDistributionControlService {
     /**
      *
      * @param hostname Name of the host
-     * @return Uname of the host Linux, CYGWIN_NT-6.3, etc
-     * @throws CommandFailureException
+     * @param remotePath remote file of directory
+     * @throws CommandFailureException exception thrown when the command fails
      */
-    CommandOutput getUName(final String hostname) throws CommandFailureException;
+    CommandOutput backupFileWithCopy(final String hostname, final String remotePath) throws CommandFailureException;
 
     /**
      *
      * @param hostname Name of the host
      * @param remotePath remote file of directory
-     * @throws CommandFailureException
+     * @throws CommandFailureException exception thrown when the command fails
      */
-    CommandOutput backupFile(final String hostname, final String remotePath) throws CommandFailureException;
+    CommandOutput backupFileWithMove(final String hostname, final String remotePath) throws CommandFailureException;
 }

--- a/jwala-services/src/main/java/com/cerner/jwala/service/binarydistribution/impl/BinaryDistributionControlServiceImpl.java
+++ b/jwala-services/src/main/java/com/cerner/jwala/service/binarydistribution/impl/BinaryDistributionControlServiceImpl.java
@@ -36,13 +36,13 @@ public class BinaryDistributionControlServiceImpl implements BinaryDistributionC
     @Autowired
     private RemoteCommandExecutorService remoteCommandExecutorService;
 
-    static String CREATE_DIR="if [ ! -e \"%s\" ]; then mkdir -p %s; fi;";
-    static String REMOVE="rm";
-    static String SECURE_COPY = "scp";
-    static String TEST = "test -e";
-    static String CHMOD = "chmod";
-    static String MOVE = "mv";
-    static String COPY = "cp";
+    private static String CREATE_DIR="if [ ! -e \"%s\" ]; then mkdir -p %s; fi;";
+    private static String REMOVE="rm";
+    private static String SECURE_COPY = "scp";
+    private static String TEST = "test -e";
+    private static String CHMOD = "chmod";
+    private static String MOVE = "mv";
+    private static String COPY = "cp";
 
     @Override
     public CommandOutput secureCopyFile(final String hostname, final String source, final String destination) throws CommandFailureException  {

--- a/jwala-services/src/main/java/com/cerner/jwala/service/binarydistribution/impl/BinaryDistributionControlServiceImpl.java
+++ b/jwala-services/src/main/java/com/cerner/jwala/service/binarydistribution/impl/BinaryDistributionControlServiceImpl.java
@@ -42,6 +42,7 @@ public class BinaryDistributionControlServiceImpl implements BinaryDistributionC
     static String TEST = "test -e";
     static String CHMOD = "chmod";
     static String MOVE = "mv";
+    static String COPY = "cp";
 
     @Override
     public CommandOutput secureCopyFile(final String hostname, final String source, final String destination) throws CommandFailureException  {
@@ -102,26 +103,22 @@ public class BinaryDistributionControlServiceImpl implements BinaryDistributionC
     }
 
     @Override
-    public CommandOutput getUName(String hostname) throws CommandFailureException {
-        RemoteCommandReturnInfo remoteCommandReturnInfo = remoteCommandExecutorService.executeCommand(new RemoteExecCommand(getConnection(hostname),  new ExecCommand("uname")));
-        CommandOutput commandOutput = new CommandOutput(new ExecReturnCode(remoteCommandReturnInfo.retCode),
-                remoteCommandReturnInfo.standardOuput, remoteCommandReturnInfo.errorOupout);
-        return commandOutput;
+    public CommandOutput backupFileWithCopy(String hostname, String remotePath) throws CommandFailureException {
+        return executeBackup(hostname, remotePath, COPY);
     }
 
     @Override
-    public CommandOutput backupFile(final String hostname, final String remotePath) throws CommandFailureException {
+    public CommandOutput backupFileWithMove(final String hostname, final String remotePath) throws CommandFailureException {
+        return executeBackup(hostname, remotePath, MOVE);
+    }
+
+    private CommandOutput executeBackup(final String hostname, final String remotePath, String command) {
         final String currentDateSuffix = new SimpleDateFormat("yyyyMMdd_HHmmss").format(Date.from(Instant.now()));
         final String destPathBackup = remotePath + "." + currentDateSuffix;
-        RemoteCommandReturnInfo remoteCommandReturnInfo = remoteCommandExecutorService.executeCommand(new RemoteExecCommand(getConnection(hostname),  new ExecCommand(MOVE, remotePath, destPathBackup)));
+        RemoteCommandReturnInfo remoteCommandReturnInfo = remoteCommandExecutorService.executeCommand(new RemoteExecCommand(getConnection(hostname),  new ExecCommand(command, remotePath, destPathBackup)));
         CommandOutput commandOutput = new CommandOutput(new ExecReturnCode(remoteCommandReturnInfo.retCode),
                 remoteCommandReturnInfo.standardOuput, remoteCommandReturnInfo.errorOupout);
         return commandOutput;
-    }
-
-    public void printCommandOutput(CommandOutput commandOutput) {
-        LOGGER.info(commandOutput.getStandardOutput());
-        LOGGER.info(commandOutput.getStandardError());
     }
 
     /**

--- a/jwala-services/src/main/java/com/cerner/jwala/service/binarydistribution/impl/BinaryDistributionServiceImpl.java
+++ b/jwala-services/src/main/java/com/cerner/jwala/service/binarydistribution/impl/BinaryDistributionServiceImpl.java
@@ -230,7 +230,7 @@ public class BinaryDistributionServiceImpl implements BinaryDistributionService 
 
     @Override
     public void backupFile(final String hostname, final String remoteFilePath) {
-        binaryDistributionControlService.backupFile(hostname, remoteFilePath);
+        binaryDistributionControlService.backupFileWithMove(hostname, remoteFilePath);
     }
 
     /**

--- a/jwala-services/src/main/java/com/cerner/jwala/service/group/impl/GroupServiceImpl.java
+++ b/jwala-services/src/main/java/com/cerner/jwala/service/group/impl/GroupServiceImpl.java
@@ -449,11 +449,11 @@ public class GroupServiceImpl implements GroupService {
                                 .setGroupName(groupName)
                                 .build()).getMetaData();
                 ResourceTemplateMetaData metaData = resourceService.getTokenizedMetaData(fileName, jvm, metaDataStr);
-                if (metaData.isHotDeploy()) {
-                    LOGGER.info("JVM {} is started but resource {} is configured for hot deploy. Continuing with deploy ...", jvm.getJvmName(), fileName);
-                } else {
+                if (!metaData.isHotDeploy()) {
                     startedAndNotHotDeployList.add(jvm.getJvmName());
+                    continue;
                 }
+                LOGGER.info("JVM {} is started but resource {} is configured for hot deploy. Continuing with deploy ...", jvm.getJvmName(), fileName);
             } catch (IOException e) {
                 String errMsg = MessageFormat.format("Failed to tokenize meta data for resource {0} of JVM {1}", fileName, jvm.getJvmName());
                 LOGGER.error(errMsg);

--- a/jwala-services/src/main/java/com/cerner/jwala/service/jvm/impl/JvmServiceImpl.java
+++ b/jwala-services/src/main/java/com/cerner/jwala/service/jvm/impl/JvmServiceImpl.java
@@ -786,7 +786,7 @@ public class JvmServiceImpl implements JvmService {
                     .setResourceName(fileName)
                     .setJvmName(jvmName)
                     .build();
-            checkJvmStateForDeploy(jvm, resourceIdentifier);
+            checkJvmStateBeforeDeploy(jvm, resourceIdentifier);
 
             resourceService.validateSingleResourceForGeneration(resourceIdentifier);
             resourceService.generateAndDeployFile(resourceIdentifier, jvm.getJvmName(), fileName, jvm.getHostName());
@@ -801,7 +801,7 @@ public class JvmServiceImpl implements JvmService {
         return jvm;
     }
 
-    private void checkJvmStateForDeploy(Jvm jvm, ResourceIdentifier resourceIdentifier) throws IOException {
+    private void checkJvmStateBeforeDeploy(Jvm jvm, ResourceIdentifier resourceIdentifier) throws IOException {
         final Jvm jvmByExactName = jvmPersistenceService.findJvmByExactName(jvm.getJvmName());
         final String metaDataString = resourceService.getResourceContent(resourceIdentifier).getMetaData();
         ResourceTemplateMetaData metaData = resourceService.getTokenizedMetaData(resourceIdentifier.resourceName, jvmByExactName, metaDataString);

--- a/jwala-services/src/main/java/com/cerner/jwala/service/jvm/impl/JvmServiceImpl.java
+++ b/jwala-services/src/main/java/com/cerner/jwala/service/jvm/impl/JvmServiceImpl.java
@@ -805,15 +805,12 @@ public class JvmServiceImpl implements JvmService {
         final Jvm jvmByExactName = jvmPersistenceService.findJvmByExactName(jvm.getJvmName());
         final String metaDataString = resourceService.getResourceContent(resourceIdentifier).getMetaData();
         ResourceTemplateMetaData metaData = resourceService.getTokenizedMetaData(resourceIdentifier.resourceName, jvmByExactName, metaDataString);
-        if (jvm.getState().isStartedState()) {
-            if (metaData.isHotDeploy()){
-                LOGGER.info("JVM {} is started, but the resource {} is hot deployable, continuing with deploy ...", jvm.getJvmName(), resourceIdentifier.resourceName);
-            } else {
+        if (jvm.getState().isStartedState() && !metaData.isHotDeploy()) {
                 String errMsg = MessageFormat.format("The target JVM {0} must be stopped or the resource {1} must be set to hotDeploy=true before attempting to update the resource files", jvm.getJvmName(), resourceIdentifier.resourceName);
                 LOGGER.error(errMsg);
                 throw new InternalErrorException(FaultType.REMOTE_COMMAND_FAILURE, errMsg);
-            }
         }
+        LOGGER.info("JVM {} is started, but the resource {} is hot deployable, continuing with deploy ...", jvm.getJvmName(), resourceIdentifier.resourceName);
     }
 
     @Override

--- a/jwala-services/src/main/java/com/cerner/jwala/service/jvm/impl/JvmServiceImpl.java
+++ b/jwala-services/src/main/java/com/cerner/jwala/service/jvm/impl/JvmServiceImpl.java
@@ -786,7 +786,7 @@ public class JvmServiceImpl implements JvmService {
                     .setResourceName(fileName)
                     .setJvmName(jvmName)
                     .build();
-            checkJvmStateForDeploy(fileName, jvm, resourceIdentifier);
+            checkJvmStateForDeploy(jvm, resourceIdentifier);
 
             resourceService.validateSingleResourceForGeneration(resourceIdentifier);
             resourceService.generateAndDeployFile(resourceIdentifier, jvm.getJvmName(), fileName, jvm.getHostName());
@@ -801,15 +801,15 @@ public class JvmServiceImpl implements JvmService {
         return jvm;
     }
 
-    private void checkJvmStateForDeploy(String fileName, Jvm jvm, ResourceIdentifier resourceIdentifier) throws IOException {
+    private void checkJvmStateForDeploy(Jvm jvm, ResourceIdentifier resourceIdentifier) throws IOException {
         final Jvm jvmByExactName = jvmPersistenceService.findJvmByExactName(jvm.getJvmName());
         final String metaDataString = resourceService.getResourceContent(resourceIdentifier).getMetaData();
-        ResourceTemplateMetaData metaData = resourceService.getTokenizedMetaData(fileName, jvmByExactName, metaDataString);
+        ResourceTemplateMetaData metaData = resourceService.getTokenizedMetaData(resourceIdentifier.resourceName, jvmByExactName, metaDataString);
         if (jvm.getState().isStartedState()) {
             if (metaData.isHotDeploy()){
-                LOGGER.info("JVM {} is started, but the resource {} is hot deployable, continuing with deploy ...", jvm.getJvmName(), fileName);
+                LOGGER.info("JVM {} is started, but the resource {} is hot deployable, continuing with deploy ...", jvm.getJvmName(), resourceIdentifier.resourceName);
             } else {
-                LOGGER.error("The target JVM {} must be stopped before attempting to update the resource files", jvm.getJvmName());
+                LOGGER.error("The target JVM {} must be stopped or the resource {} must be set to hotDeploy=true before attempting to update the resource files", jvm.getJvmName(), resourceIdentifier.resourceName);
                 throw new InternalErrorException(FaultType.REMOTE_COMMAND_FAILURE,
                         "The target JVM must be stopped before attempting to update the resource files");
             }

--- a/jwala-services/src/main/java/com/cerner/jwala/service/jvm/impl/JvmServiceImpl.java
+++ b/jwala-services/src/main/java/com/cerner/jwala/service/jvm/impl/JvmServiceImpl.java
@@ -782,22 +782,38 @@ public class JvmServiceImpl implements JvmService {
         // only one at a time per jvm
         binaryDistributionLockManager.writeLock(jvmName + "-" + jvm.getId().getId().toString());
         try {
-            if (jvm.getState().isStartedState()) {
-                LOGGER.error("The target JVM {} must be stopped before attempting to update the resource files", jvm.getJvmName());
-                throw new InternalErrorException(FaultType.REMOTE_COMMAND_FAILURE,
-                        "The target JVM must be stopped before attempting to update the resource files");
-            }
             ResourceIdentifier resourceIdentifier = new ResourceIdentifier.Builder()
                     .setResourceName(fileName)
                     .setJvmName(jvmName)
                     .build();
+            checkJvmStateForDeploy(fileName, jvm, resourceIdentifier);
+
             resourceService.validateSingleResourceForGeneration(resourceIdentifier);
             resourceService.generateAndDeployFile(resourceIdentifier, jvm.getJvmName(), fileName, jvm.getHostName());
+        } catch (IOException e) {
+            String errorMsg = MessageFormat.format("Failed to retrieve meta data when generating and deploying file {0} for JVM {1}", fileName, jvmName);
+            LOGGER.error(errorMsg, e);
+            throw new JvmServiceException(errorMsg);
         } finally {
             binaryDistributionLockManager.writeUnlock(jvmName + "-" + jvm.getId().getId().toString());
             LOGGER.debug("End generateAndDeployFile for {} by user {}", jvmName, user.getId());
         }
         return jvm;
+    }
+
+    private void checkJvmStateForDeploy(String fileName, Jvm jvm, ResourceIdentifier resourceIdentifier) throws IOException {
+        final Jvm jvmByExactName = jvmPersistenceService.findJvmByExactName(jvm.getJvmName());
+        final String metaDataString = resourceService.getResourceContent(resourceIdentifier).getMetaData();
+        ResourceTemplateMetaData metaData = resourceService.getTokenizedMetaData(fileName, jvmByExactName, metaDataString);
+        if (jvm.getState().isStartedState()) {
+            if (metaData.isHotDeploy()){
+                LOGGER.info("JVM {} is started, but the resource {} is hot deployable, continuing with deploy ...", jvm.getJvmName(), fileName);
+            } else {
+                LOGGER.error("The target JVM {} must be stopped before attempting to update the resource files", jvm.getJvmName());
+                throw new InternalErrorException(FaultType.REMOTE_COMMAND_FAILURE,
+                        "The target JVM must be stopped before attempting to update the resource files");
+            }
+        }
     }
 
     @Override

--- a/jwala-services/src/main/java/com/cerner/jwala/service/jvm/impl/JvmServiceImpl.java
+++ b/jwala-services/src/main/java/com/cerner/jwala/service/jvm/impl/JvmServiceImpl.java
@@ -809,9 +809,9 @@ public class JvmServiceImpl implements JvmService {
             if (metaData.isHotDeploy()){
                 LOGGER.info("JVM {} is started, but the resource {} is hot deployable, continuing with deploy ...", jvm.getJvmName(), resourceIdentifier.resourceName);
             } else {
-                LOGGER.error("The target JVM {} must be stopped or the resource {} must be set to hotDeploy=true before attempting to update the resource files", jvm.getJvmName(), resourceIdentifier.resourceName);
-                throw new InternalErrorException(FaultType.REMOTE_COMMAND_FAILURE,
-                        "The target JVM must be stopped before attempting to update the resource files");
+                String errMsg = MessageFormat.format("The target JVM {0} must be stopped or the resource {1} must be set to hotDeploy=true before attempting to update the resource files", jvm.getJvmName(), resourceIdentifier.resourceName);
+                LOGGER.error(errMsg);
+                throw new InternalErrorException(FaultType.REMOTE_COMMAND_FAILURE, errMsg);
             }
         }
     }

--- a/jwala-services/src/main/java/com/cerner/jwala/service/resource/impl/handler/GroupLevelAppResourceHandler.java
+++ b/jwala-services/src/main/java/com/cerner/jwala/service/resource/impl/handler/GroupLevelAppResourceHandler.java
@@ -106,7 +106,15 @@ public class GroupLevelAppResourceHandler extends ResourceHandler {
 
     private ResourceTemplateMetaData updateApplicationWarMetaData(ResourceIdentifier resourceIdentifier, ResourceTemplateMetaData metaDataCopy, Application app) {
         boolean isUnpackWar = app.isUnpackWar();
-        metaDataCopy = new ResourceTemplateMetaData(metaDataCopy.getTemplateName(), metaDataCopy.getContentType(), metaDataCopy.getDeployFileName(), metaDataCopy.getDeployPath(), metaDataCopy.getEntity(), isUnpackWar, metaDataCopy.isOverwrite());
+        metaDataCopy = new ResourceTemplateMetaData(
+                metaDataCopy.getTemplateName(),
+                metaDataCopy.getContentType(),
+                metaDataCopy.getDeployFileName(),
+                metaDataCopy.getDeployPath(),
+                metaDataCopy.getEntity(),
+                isUnpackWar,
+                metaDataCopy.isOverwrite(),
+                metaDataCopy.isHotDeploy());
 
         try {
             final ObjectMapper objectMapper = new ObjectMapper();

--- a/jwala-services/src/main/java/com/cerner/jwala/service/webserver/impl/WebServerServiceImpl.java
+++ b/jwala-services/src/main/java/com/cerner/jwala/service/webserver/impl/WebServerServiceImpl.java
@@ -374,14 +374,11 @@ public class WebServerServiceImpl implements WebServerService {
     private void checkWebServerStateBeforeDeploy(WebServer webServer, ResourceIdentifier resourceIdentifier) throws IOException {
         final String metaDataStr = resourceService.getResourceContent(resourceIdentifier).getMetaData();
         ResourceTemplateMetaData metaData = resourceService.getTokenizedMetaData(resourceIdentifier.resourceName, webServer, metaDataStr);
-        if (isStarted(webServer)) {
-            if (metaData.isHotDeploy()) {
-                LOGGER.info("Web Server {} is started, but resource {} is configured to be hot deployed. Continuing with deploy ...", resourceIdentifier.webServerName, resourceIdentifier.resourceName);
-            } else {
+        if (isStarted(webServer) && !metaData.isHotDeploy()) {
                 String errorMsg = MessageFormat.format("The target Web Server {0} must be stopped or the resource must be configured to be hotDeploy=true before attempting to deploy the resource {1}", resourceIdentifier.webServerName, resourceIdentifier.resourceName);
                 LOGGER.error(errorMsg);
                 throw new InternalErrorException(FaultType.REMOTE_COMMAND_FAILURE, errorMsg);
-            }
         }
+        LOGGER.info("Web Server {} is started, but resource {} is configured to be hot deployed. Continuing with deploy ...", resourceIdentifier.webServerName, resourceIdentifier.resourceName);
     }
 }

--- a/jwala-services/src/main/java/com/cerner/jwala/service/webserver/impl/WebServerServiceImpl.java
+++ b/jwala-services/src/main/java/com/cerner/jwala/service/webserver/impl/WebServerServiceImpl.java
@@ -350,21 +350,38 @@ public class WebServerServiceImpl implements WebServerService {
     public WebServer generateAndDeployFile(String webServerName, String fileName, User user) {
         WebServer webServer = getWebServer(webServerName);
         binaryDistributionLockManager.writeLock(webServerName + "-" + webServer.getId().getId().toString());
+        ResourceIdentifier resourceIdentifier = new ResourceIdentifier.Builder()
+                .setWebServerName(webServerName)
+                .setResourceName(fileName)
+                .build();
+
         try {
-            // check the web server state
-            if (isStarted(getWebServer(webServerName))) {
-                LOGGER.error("The target Web Server {} must be stopped before attempting to update the resource file", webServerName);
-                throw new InternalErrorException(FaultType.REMOTE_COMMAND_FAILURE, "The target Web Server must be stopped before attempting to update the resource file");
-            }
-            ResourceIdentifier resourceIdentifier = new ResourceIdentifier.Builder()
-                    .setWebServerName(webServerName)
-                    .setResourceName(fileName)
-                    .build();
+            checkWebServerStateBeforeDeploy(webServer, resourceIdentifier);
+
             resourceService.validateSingleResourceForGeneration(resourceIdentifier);
             resourceService.generateAndDeployFile(resourceIdentifier, webServerName, fileName, webServer.getHost());
+        } catch (IOException e) {
+            String errorMsg = MessageFormat.format("Failed to retrieve meta data when generating and deploying file {0} for Web Server {1}", fileName, webServerName);
+            LOGGER.error(errorMsg, e);
+            throw new WebServerServiceException(errorMsg);
         } finally {
             binaryDistributionLockManager.writeUnlock(webServerName + "-" + webServer.getId().getId().toString());
         }
+
         return webServer;
+    }
+
+    private void checkWebServerStateBeforeDeploy(WebServer webServer, ResourceIdentifier resourceIdentifier) throws IOException {
+        final String metaDataStr = resourceService.getResourceContent(resourceIdentifier).getMetaData();
+        ResourceTemplateMetaData metaData = resourceService.getTokenizedMetaData(resourceIdentifier.resourceName, webServer, metaDataStr);
+        if (isStarted(webServer)) {
+            if (metaData.isHotDeploy()) {
+                LOGGER.info("Web Server {} is started, but resource {} is configured to be hot deployed. Continuing with deploy ...", resourceIdentifier.webServerName, resourceIdentifier.resourceName);
+            } else {
+                String errorMsg = MessageFormat.format("The target Web Server {0} must be stopped or the resource must be configured to be hotDeploy=true before attempting to deploy the resource {1}", resourceIdentifier.webServerName, resourceIdentifier.resourceName);
+                LOGGER.error(errorMsg);
+                throw new InternalErrorException(FaultType.REMOTE_COMMAND_FAILURE, errorMsg);
+            }
+        }
     }
 }

--- a/jwala-services/src/test/java/com/cerner/jwala/commandprocessor/impl/jsch/JschRequestProcessorImplTest.java
+++ b/jwala-services/src/test/java/com/cerner/jwala/commandprocessor/impl/jsch/JschRequestProcessorImplTest.java
@@ -1,16 +1,13 @@
 package com.cerner.jwala.commandprocessor.impl.jsch;
 
 import com.cerner.jwala.commandprocessor.impl.CommonSshTestConfiguration;
-import com.cerner.jwala.common.IntegrationTestRule;
 import com.cerner.jwala.common.exec.ExecCommand;
-import com.cerner.jwala.common.exec.ExecReturnCode;
 import com.cerner.jwala.common.exec.RemoteExecCommand;
 import com.cerner.jwala.common.exec.RemoteSystemConnection;
 import com.cerner.jwala.exception.ExitCodeNotAvailableException;
 import com.cerner.jwala.exception.RemoteCommandFailureException;
 import com.jcraft.jsch.JSchException;
 import org.junit.Before;
-import org.junit.ClassRule;
 import org.junit.Ignore;
 import org.junit.Test;
 

--- a/jwala-services/src/test/java/com/cerner/jwala/service/app/impl/ApplicationServiceImplTest.java
+++ b/jwala-services/src/test/java/com/cerner/jwala/service/app/impl/ApplicationServiceImplTest.java
@@ -609,7 +609,7 @@ public class ApplicationServiceImplTest {
         when(Config.binaryDistributionControlService.secureCopyFile(anyString(), anyString(), anyString())).thenReturn(new CommandOutput(new ExecReturnCode(0), "Secure copy succeeded", ""));
         when(Config.binaryDistributionControlService.changeFileMode(anyString(), anyString(), anyString(), anyString())).thenReturn(new CommandOutput(new ExecReturnCode(0), "Change file mode succeeded", ""));
         when(Config.binaryDistributionControlService.checkFileExists(anyString(), anyString())).thenReturn(new CommandOutput(new ExecReturnCode(0), "File exists succeeded", ""));
-        when(Config.binaryDistributionControlService.backupFile(anyString(), anyString())).thenReturn(new CommandOutput(new ExecReturnCode(0), "Backup succeeded", ""));
+        when(Config.binaryDistributionControlService.backupFileWithMove(anyString(), anyString())).thenReturn(new CommandOutput(new ExecReturnCode(0), "Backup succeeded", ""));
         when(Config.binaryDistributionControlService.unzipBinary(anyString(), anyString(), anyString(), anyString())).thenReturn(new CommandOutput(new ExecReturnCode(0), "Unzip succeeded", ""));
 
         applicationService.copyApplicationWarToGroupHosts(mockApplicationForCopy);

--- a/jwala-services/src/test/java/com/cerner/jwala/service/app/impl/ApplicationServiceImplTest.java
+++ b/jwala-services/src/test/java/com/cerner/jwala/service/app/impl/ApplicationServiceImplTest.java
@@ -216,7 +216,7 @@ public class ApplicationServiceImplTest {
 
         when(Config.mockGroupPersistenceService.getGroupAppResourceTemplateMetaData(anyString(), anyString())).thenReturn("{\"templateName\":\"test-template-name\", \"contentType\":\"application/zip\", \"deployFileName\":\"test-app.war\", \"deployPath\":\"/fake/deploy/path\", \"entity\":{}, \"unpack\":\"true\", \"overwrite\":\"true\"}");
 
-        when(Config.mockResourceService.getMetaData(anyString())).thenReturn(new ResourceTemplateMetaData("test-template-name", MediaType.APPLICATION_ZIP, "deploy-file-name", "deploy-path", null, true, false));
+        when(Config.mockResourceService.getMetaData(anyString())).thenReturn(new ResourceTemplateMetaData("test-template-name", MediaType.APPLICATION_ZIP, "deploy-file-name", "deploy-path", null, true, false, null));
 
         UpdateApplicationRequest cac = new UpdateApplicationRequest(Config.mockApplication2.getId(), Identifier.id(1L, Group.class), "wan", "/wan", true, true, false);
         Application created = applicationService.updateApplication(cac, new User("user"));

--- a/jwala-services/src/test/java/com/cerner/jwala/service/app/impl/ApplicationServiceImplTest.java
+++ b/jwala-services/src/test/java/com/cerner/jwala/service/app/impl/ApplicationServiceImplTest.java
@@ -315,6 +315,8 @@ public class ApplicationServiceImplTest {
 
     @Test(expected = InternalErrorException.class)
     public void testDeployConfJvmNotStopped() throws IOException {
+        reset(Config.jvmPersistenceService, Config.applicationPersistenceService, Config.mockResourceService);
+
         Jvm mockJvm = mock(Jvm.class);
         when(mockJvm.getState()).thenReturn(JvmState.JVM_STARTED);
         when(Config.jvmPersistenceService.findJvmByExactName(anyString())).thenReturn(mockJvm);
@@ -326,6 +328,8 @@ public class ApplicationServiceImplTest {
         when(Config.mockResourceService.getResourceContent(any(ResourceIdentifier.class))).thenReturn(new ResourceContent("{\"test\":\"meta data\"}", "test resource content"));
         when(Config.mockResourceService.getTokenizedMetaData(anyString(), anyObject(), anyString())).thenReturn(mockMetaData);
         applicationService.deployConf("testApp", "testGroup", "testJvm", "HttpSslConfTemplate.tpl", mock(ResourceGroup.class), testUser);
+
+        verify(Config.mockResourceService, never()).generateAndDeployFile(any(ResourceIdentifier.class), anyString(), anyString(), anyString());
     }
 
     @Test

--- a/jwala-services/src/test/java/com/cerner/jwala/service/jvm/impl/JvmServiceImplTest.java
+++ b/jwala-services/src/test/java/com/cerner/jwala/service/jvm/impl/JvmServiceImplTest.java
@@ -902,6 +902,21 @@ public class JvmServiceImplTest extends VerificationBehaviorSupport {
         verify(Config.mockResourceService).generateAndDeployFile(any(ResourceIdentifier.class), anyString(), anyString(), anyString());
     }
 
+    @Test (expected = JvmServiceException.class)
+    public void testGenerateAndDeployFileJvmStartedHotDeployTrueThrowsIOException() throws IOException {
+        Jvm mockJvm = mock(Jvm.class);
+        when(mockJvm.getState()).thenReturn(JvmState.JVM_STARTED);
+        when(mockJvm.getId()).thenReturn(new Identifier<Jvm>(11111L));
+        when(Config.mockResourceService.getResourceContent(any(ResourceIdentifier.class))).thenReturn(new ResourceContent("{\"fake\":\"meta-data\"}","some template content"));
+        when(Config.mockResourceService.getTokenizedMetaData(anyString(), any(Jvm.class), anyString())).thenThrow(new IOException("Test throwing the IOException during tokenization"));
+        when(Config.mockJvmPersistenceService.findJvmByExactName(anyString())).thenReturn(mockJvm);
+
+        jvmService.generateAndDeployFile("jvmName", "fileName", Config.mockUser);
+
+        verify(Config.mockResourceService, never()).validateSingleResourceForGeneration(any(ResourceIdentifier.class));
+        verify(Config.mockResourceService, never()).generateAndDeployFile(any(ResourceIdentifier.class), anyString(), anyString(), anyString());
+    }
+
     @Test
     public void testGenerateJvmConfigJar() {
         Set<Group> groups = new HashSet<Group>() {{

--- a/jwala-services/src/test/java/com/cerner/jwala/service/jvm/impl/JvmServiceImplTest.java
+++ b/jwala-services/src/test/java/com/cerner/jwala/service/jvm/impl/JvmServiceImplTest.java
@@ -10,6 +10,7 @@ import com.cerner.jwala.common.domain.model.jvm.JvmControlOperation;
 import com.cerner.jwala.common.domain.model.jvm.JvmState;
 import com.cerner.jwala.common.domain.model.media.Media;
 import com.cerner.jwala.common.domain.model.path.Path;
+import com.cerner.jwala.common.domain.model.resource.ResourceContent;
 import com.cerner.jwala.common.domain.model.resource.ResourceGroup;
 import com.cerner.jwala.common.domain.model.resource.ResourceIdentifier;
 import com.cerner.jwala.common.domain.model.resource.ResourceTemplateMetaData;
@@ -24,7 +25,6 @@ import com.cerner.jwala.common.request.group.AddJvmToGroupRequest;
 import com.cerner.jwala.common.request.jvm.*;
 import com.cerner.jwala.control.AemControl;
 import com.cerner.jwala.exception.CommandFailureException;
-import com.cerner.jwala.persistence.jpa.service.exception.NonRetrievableResourceTemplateContentException;
 import com.cerner.jwala.persistence.jpa.type.EventType;
 import com.cerner.jwala.persistence.service.GroupPersistenceService;
 import com.cerner.jwala.persistence.service.JvmPersistenceService;
@@ -823,6 +823,8 @@ public class JvmServiceImplTest extends VerificationBehaviorSupport {
         when(mockExecData.getReturnCode()).thenReturn(new ExecReturnCode(0));
         when(Config.mockJvmPersistenceService.findJvmByExactName(anyString())).thenReturn(mockJvm);
         when(Config.mockResourceService.generateResourceFile(anyString(), anyString(), any(ResourceGroup.class), anyString(), any(ResourceGeneratorType.class))).thenReturn("<server>xml</server>");
+        when(Config.mockResourceService.getResourceContent(any(ResourceIdentifier.class))).thenReturn(new ResourceContent("{\"fake\":\"meta-data\"}","some template content"));
+        when(Config.mockResourceService.getTokenizedMetaData(anyString(), any(Jvm.class), anyString())).thenReturn(new ResourceTemplateMetaData("template-name", MediaType.APPLICATION_XML, "deploy-file-name", "deploy-path", null, false, true, false));
         when(Config.mockJvmPersistenceService.getJvmTemplate(anyString(), any(Identifier.class))).thenReturn("<server>xml</server>");
         when(Config.mockJvmControlService.secureCopyFile(any(ControlJvmRequest.class), anyString(), anyString(), anyString(), anyBoolean())).thenReturn(mockExecData);
         when(Config.mockJvmControlService.executeCreateDirectoryCommand(any(Jvm.class), anyString())).thenReturn(mockExecData);
@@ -832,6 +834,7 @@ public class JvmServiceImplTest extends VerificationBehaviorSupport {
         when(mockMetaData.getDeployPath()).thenReturn("/");
         when(mockMetaData.getContentType()).thenReturn(MediaType.APPLICATION_XML);
         when(Config.mockResourceService.getTokenizedMetaData(anyString(), Matchers.anyObject(), anyString())).thenReturn(mockMetaData);
+
         Jvm jvm = jvmService.generateAndDeployFile("test-jvm-deploy-file", "server.xml", Config.mockUser);
         assertEquals(mockJvm, jvm);
 
@@ -874,12 +877,29 @@ public class JvmServiceImplTest extends VerificationBehaviorSupport {
     }
 
     @Test(expected = InternalErrorException.class)
-    public void testGenerateAndDeployFileJvmStarted() {
+    public void testGenerateAndDeployFileJvmStarted() throws IOException {
         Jvm mockJvm = mock(Jvm.class);
         when(mockJvm.getState()).thenReturn(JvmState.JVM_STARTED);
         when(mockJvm.getId()).thenReturn(new Identifier<Jvm>(11111L));
+        when(Config.mockResourceService.getResourceContent(any(ResourceIdentifier.class))).thenReturn(new ResourceContent("{\"fake\":\"meta-data\"}","some template content"));
+        when(Config.mockResourceService.getTokenizedMetaData(anyString(), any(Jvm.class), anyString())).thenReturn(new ResourceTemplateMetaData("template-name", MediaType.APPLICATION_XML, "deploy-file-name", "deploy-path", null, false, true, false));
         when(Config.mockJvmPersistenceService.findJvmByExactName(anyString())).thenReturn(mockJvm);
         jvmService.generateAndDeployFile("jvmName", "fileName", Config.mockUser);
+    }
+
+    @Test
+    public void testGenerateAndDeployFileJvmStartedHotDeployTrue() throws IOException {
+        Jvm mockJvm = mock(Jvm.class);
+        when(mockJvm.getState()).thenReturn(JvmState.JVM_STARTED);
+        when(mockJvm.getId()).thenReturn(new Identifier<Jvm>(11111L));
+        when(Config.mockResourceService.getResourceContent(any(ResourceIdentifier.class))).thenReturn(new ResourceContent("{\"fake\":\"meta-data\"}","some template content"));
+        when(Config.mockResourceService.getTokenizedMetaData(anyString(), any(Jvm.class), anyString())).thenReturn(new ResourceTemplateMetaData("template-name", MediaType.APPLICATION_XML, "deploy-file-name", "deploy-path", null, false, true, true));
+        when(Config.mockJvmPersistenceService.findJvmByExactName(anyString())).thenReturn(mockJvm);
+
+        jvmService.generateAndDeployFile("jvmName", "fileName", Config.mockUser);
+
+        verify(Config.mockResourceService).validateSingleResourceForGeneration(any(ResourceIdentifier.class));
+        verify(Config.mockResourceService).generateAndDeployFile(any(ResourceIdentifier.class), anyString(), anyString(), anyString());
     }
 
     @Test

--- a/jwala-services/src/test/java/com/cerner/jwala/service/resource/ResourceServiceImplTest.java
+++ b/jwala-services/src/test/java/com/cerner/jwala/service/resource/ResourceServiceImplTest.java
@@ -954,7 +954,7 @@ public class ResourceServiceImplTest {
 
         when(Config.mockBinaryDistributionControlService.createDirectory(anyString(), anyString())).thenReturn(new CommandOutput(new ExecReturnCode(0), "Created directory", ""));
         when(Config.mockDistributionService.remoteFileCheck(anyString(), anyString())).thenReturn(true);
-        when(Config.mockBinaryDistributionControlService.backupFile(anyString(), anyString())).thenReturn(new CommandOutput(new ExecReturnCode(0), "Backup succeeded", ""));
+        when(Config.mockBinaryDistributionControlService.backupFileWithMove(anyString(), anyString())).thenReturn(new CommandOutput(new ExecReturnCode(0), "Backup succeeded", ""));
         final CommandOutput scpResult = new CommandOutput(new ExecReturnCode(0), "SCP succeeded", "");
         when(Config.mockBinaryDistributionControlService.secureCopyFile(anyString(), anyString(), anyString())).thenReturn(scpResult);
 
@@ -1025,7 +1025,7 @@ public class ResourceServiceImplTest {
 
         when(Config.mockBinaryDistributionControlService.createDirectory(anyString(), anyString())).thenReturn(new CommandOutput(new ExecReturnCode(0), "Created directory", ""));
         when(Config.mockDistributionService.remoteFileCheck(anyString(), anyString())).thenReturn(true);
-        when(Config.mockBinaryDistributionControlService.backupFile(anyString(), anyString())).thenReturn(new CommandOutput(new ExecReturnCode(1), "", "BACK UP FAILED"));
+        when(Config.mockBinaryDistributionControlService.backupFileWithMove(anyString(), anyString())).thenReturn(new CommandOutput(new ExecReturnCode(1), "", "BACK UP FAILED"));
         final CommandOutput scpResult = new CommandOutput(new ExecReturnCode(0), "SCP succeeded", "");
         when(Config.mockBinaryDistributionControlService.secureCopyFile(anyString(), anyString(), anyString())).thenReturn(scpResult);
 

--- a/jwala-services/src/test/java/com/cerner/jwala/service/webserver/impl/WebServerServiceImplTest.java
+++ b/jwala-services/src/test/java/com/cerner/jwala/service/webserver/impl/WebServerServiceImplTest.java
@@ -546,6 +546,99 @@ public class WebServerServiceImplTest {
         verify(Config.mockWebServerPersistenceService, never()).removeWebServer(id);
     }
 
+    @Test
+    public void testGenerateAndDeploy() throws IOException {
+        User mockUser = mock(User.class);
+        when(mockUser.getId()).thenReturn("test-ws-user");
+
+        WebServer mockWS = mock(WebServer.class);
+        when(mockWS.getId()).thenReturn(new Identifier<WebServer>(1111L));
+        when(mockWS.getHost()).thenReturn("test-ws-host");
+        when(mockWS.getState()).thenReturn(WebServerReachableState.WS_UNREACHABLE);
+        when(Config.mockWebServerPersistenceService.findWebServerByName(eq("test-web-server"))).thenReturn(mockWS);
+
+        ResourceTemplateMetaData mockResourceTemplateMetaData = mock(ResourceTemplateMetaData.class);
+        when(mockResourceTemplateMetaData.isHotDeploy()).thenReturn(false);
+        when(Config.mockResourceService.getResourceContent(any(ResourceIdentifier.class))).thenReturn(new ResourceContent("{\"fake\" : \"meta data\"}", "test resource ws content"));
+        when(Config.mockResourceService.getTokenizedMetaData(eq("test-ws-resource.txt"),eq(mockWS), eq("{\"fake\" : \"meta data\"}"))).thenReturn(mockResourceTemplateMetaData);
+
+        wsService.generateAndDeployFile("test-web-server","test-ws-resource.txt", mockUser);
+
+        verify(Config.mockBinaryDistributionLockManager).writeLock(anyString());
+        verify(Config.mockBinaryDistributionLockManager).writeUnlock(anyString());
+        verify(Config.mockResourceService).validateSingleResourceForGeneration(any(ResourceIdentifier.class));
+        verify(Config.mockResourceService).generateAndDeployFile(any(ResourceIdentifier.class), eq("test-web-server"), eq("test-ws-resource.txt"), eq("test-ws-host"));
+    }
+
+    @Test
+    public void testGenerateAndDeployWebServerStartedAndHotDeploy() throws IOException {
+        User mockUser = mock(User.class);
+        when(mockUser.getId()).thenReturn("test-ws-user");
+
+        WebServer mockWS = mock(WebServer.class);
+        when(mockWS.getId()).thenReturn(new Identifier<WebServer>(1111L));
+        when(mockWS.getHost()).thenReturn("test-ws-host");
+        when(mockWS.getState()).thenReturn(WebServerReachableState.WS_REACHABLE);
+        when(Config.mockWebServerPersistenceService.findWebServerByName(eq("test-web-server"))).thenReturn(mockWS);
+
+        ResourceTemplateMetaData mockResourceTemplateMetaData = mock(ResourceTemplateMetaData.class);
+        when(mockResourceTemplateMetaData.isHotDeploy()).thenReturn(true);
+        when(Config.mockResourceService.getResourceContent(any(ResourceIdentifier.class))).thenReturn(new ResourceContent("{\"fake\" : \"meta data\"}", "test resource ws content"));
+        when(Config.mockResourceService.getTokenizedMetaData(eq("test-ws-resource.txt"),eq(mockWS), eq("{\"fake\" : \"meta data\"}"))).thenReturn(mockResourceTemplateMetaData);
+
+        wsService.generateAndDeployFile("test-web-server","test-ws-resource.txt", mockUser);
+
+        verify(Config.mockBinaryDistributionLockManager).writeLock(anyString());
+        verify(Config.mockBinaryDistributionLockManager).writeUnlock(anyString());
+        verify(Config.mockResourceService).validateSingleResourceForGeneration(any(ResourceIdentifier.class));
+        verify(Config.mockResourceService).generateAndDeployFile(any(ResourceIdentifier.class), eq("test-web-server"), eq("test-ws-resource.txt"), eq("test-ws-host"));
+    }
+
+    @Test (expected = InternalErrorException.class)
+    public void testGenerateAndDeployWebServerStartedAndHotDeployFalse() throws IOException {
+        User mockUser = mock(User.class);
+        when(mockUser.getId()).thenReturn("test-ws-user");
+
+        WebServer mockWS = mock(WebServer.class);
+        when(mockWS.getId()).thenReturn(new Identifier<WebServer>(1111L));
+        when(mockWS.getHost()).thenReturn("test-ws-host");
+        when(mockWS.getState()).thenReturn(WebServerReachableState.WS_REACHABLE);
+        when(Config.mockWebServerPersistenceService.findWebServerByName(eq("test-web-server"))).thenReturn(mockWS);
+
+        ResourceTemplateMetaData mockResourceTemplateMetaData = mock(ResourceTemplateMetaData.class);
+        when(mockResourceTemplateMetaData.isHotDeploy()).thenReturn(false);
+        when(Config.mockResourceService.getResourceContent(any(ResourceIdentifier.class))).thenReturn(new ResourceContent("{\"fake\" : \"meta data\"}", "test resource ws content"));
+        when(Config.mockResourceService.getTokenizedMetaData(eq("test-ws-resource.txt"),eq(mockWS), eq("{\"fake\" : \"meta data\"}"))).thenReturn(mockResourceTemplateMetaData);
+
+        wsService.generateAndDeployFile("test-web-server","test-ws-resource.txt", mockUser);
+
+        verify(Config.mockBinaryDistributionLockManager).writeLock(anyString());
+        verify(Config.mockBinaryDistributionLockManager).writeUnlock(anyString());
+        verify(Config.mockResourceService, never()).validateSingleResourceForGeneration(any(ResourceIdentifier.class));
+        verify(Config.mockResourceService, never()).generateAndDeployFile(any(ResourceIdentifier.class), eq("test-web-server"), eq("test-ws-resource.txt"), eq("test-ws-host"));
+    }
+
+    @Test (expected = WebServerServiceException.class)
+    public void testGenerateAndDeployFailsToTokenizeMetaData() throws IOException {
+        User mockUser = mock(User.class);
+        when(mockUser.getId()).thenReturn("test-ws-user");
+
+        WebServer mockWS = mock(WebServer.class);
+        when(mockWS.getId()).thenReturn(new Identifier<WebServer>(1111L));
+        when(mockWS.getHost()).thenReturn("test-ws-host");
+        when(Config.mockWebServerPersistenceService.findWebServerByName(eq("test-web-server"))).thenReturn(mockWS);
+
+        when(Config.mockResourceService.getResourceContent(any(ResourceIdentifier.class))).thenReturn(new ResourceContent("{\"fake\" : \"meta data\"}", "test resource ws content"));
+        when(Config.mockResourceService.getTokenizedMetaData(eq("test-ws-resource.txt"),eq(mockWS), eq("{\"fake\" : \"meta data\"}"))).thenThrow(new IOException("FAIL THIS TEST"));
+
+        wsService.generateAndDeployFile("test-web-server","test-ws-resource.txt", mockUser);
+
+        verify(Config.mockBinaryDistributionLockManager).writeLock(anyString());
+        verify(Config.mockBinaryDistributionLockManager).writeUnlock(anyString());
+        verify(Config.mockResourceService, never()).validateSingleResourceForGeneration(any(ResourceIdentifier.class));
+        verify(Config.mockResourceService, never()).generateAndDeployFile(any(ResourceIdentifier.class), eq("test-web-server"), eq("test-ws-resource.txt"), eq("test-ws-host"));
+    }
+
     static class Config {
 
         private static WebServerPersistenceService mockWebServerPersistenceService = mock(WebServerPersistenceService.class);

--- a/jwala-webservices/src/main/java/com/cerner/jwala/ws/rest/v1/service/group/impl/GroupServiceRestImpl.java
+++ b/jwala-webservices/src/main/java/com/cerner/jwala/ws/rest/v1/service/group/impl/GroupServiceRestImpl.java
@@ -690,7 +690,6 @@ public class GroupServiceRestImpl implements GroupServiceRest {
         LOGGER.info("Generate and deploy group app file {} for group {} by user {} to host {}", fileName, groupName, aUser.getUser().getId(), hostName);
 
         Group group = groupService.getGroup(groupName);
-        Application app = applicationService.getApplication(appName);
         final String groupAppMetaData = groupService.getGroupAppResourceTemplateMetaData(groupName, fileName);
         ResourceTemplateMetaData metaData;
         try {

--- a/jwala-webservices/src/test/java/com/cerner/jwala/ws/rest/v1/service/group/impl/GroupServiceImplDeployTest.java
+++ b/jwala-webservices/src/test/java/com/cerner/jwala/ws/rest/v1/service/group/impl/GroupServiceImplDeployTest.java
@@ -191,13 +191,16 @@ public class GroupServiceImplDeployTest {
         ResourceTemplateMetaData mockMetaData = mock(ResourceTemplateMetaData.class);
         Entity mockEntity = mock(Entity.class);
         when(mockMetaData.getEntity()).thenReturn(mockEntity);
-        when(mockEntity.getDeployToJvms()).thenReturn(true);
-        when(Config.mockResourceService.getMetaData(anyString())).thenReturn(mockMetaData);
+        when(mockMetaData.isHotDeploy()).thenReturn(false);
+        when(Config.mockApplicationService.getApplication(anyString())).thenReturn(mockApp);
+        when(Config.mockResourceService.getTokenizedMetaData(anyString(), any(Application.class), anyString())).thenReturn(mockMetaData);
+        when(Config.mockGroupService.deployGroupAppTemplate(anyString(), anyString(), any(Application.class), any(Jvm.class))).thenReturn(new CommandOutput(new ExecReturnCode(0), "SUCCESS", ""));
 
         Response returnResponse = groupServiceRest.generateAndDeployGroupAppFile("testGroup", "hct.xml", "testApp", mockAuthUser, null);
         assertEquals(200, returnResponse.getStatus());
 
         when(mockJvm.getHostName()).thenReturn("TestHost");
+        when(Config.mockGroupService.deployGroupAppTemplate(anyString(), anyString(), any(Application.class), anyString())).thenReturn(new CommandOutput(new ExecReturnCode(0), "SUCCESS", ""));
         returnResponse = groupServiceRest.generateAndDeployGroupAppFile("testGroup", "hct.xml", "testApp", mockAuthUser, hostName);
         assertEquals(200, returnResponse.getStatus());
 
@@ -225,7 +228,7 @@ public class GroupServiceImplDeployTest {
             groupServiceRest.generateAndDeployGroupAppFile("testGroup", "hct.xml", "testApp", mockAuthUser, null);
         } catch (InternalErrorException ie) {
             internalErrorException = true;
-            assertTrue(ie.getMessage().contains("All JVMs in the group must be stopped"));
+            assertTrue(ie.getMessage().contains("not all JVMs were stopped"));
         }
         assertTrue(internalErrorException);
     }
@@ -262,7 +265,9 @@ public class GroupServiceImplDeployTest {
         when(mockMetaData.getEntity()).thenReturn(mockEntity);
         when(mockEntity.getDeployToJvms()).thenReturn(false);
         when(mockEntity.getTarget()).thenReturn("testApp");
-        when(Config.mockResourceService.getMetaData(anyString())).thenReturn(mockMetaData);
+        when(mockMetaData.isHotDeploy()).thenReturn(false);
+        when(Config.mockApplicationService.getApplication(anyString())).thenReturn(mockApp);
+        when(Config.mockResourceService.getTokenizedMetaData(anyString(), any(Application.class), anyString())).thenReturn(mockMetaData);
         Response returnResponse = groupServiceRest.generateAndDeployGroupAppFile("testGroup", "hct.xml", "testApp", mockAuthUser, null);
         assertEquals(200, returnResponse.getStatus());
 
@@ -280,6 +285,7 @@ public class GroupServiceImplDeployTest {
     public void testGroupAppDeployToHostsFailedForStartedJvm() throws IOException {
         Group mockGroup = mock(Group.class);
         Jvm mockJvm = mock(Jvm.class);
+        Application mockApp = mock(Application.class);
         when(mockJvm.getHostName()).thenReturn("test-host-name");
         when(mockJvm.getState()).thenReturn(JvmState.JVM_STARTED);
         when(mockJvm.getJvmName()).thenReturn("test-jvm-name");
@@ -291,8 +297,10 @@ public class GroupServiceImplDeployTest {
         ResourceTemplateMetaData mockMetaData = mock(ResourceTemplateMetaData.class);
         Entity mockMetaDataEntity = mock(Entity.class);
         when(mockMetaData.getEntity()).thenReturn(mockMetaDataEntity);
+        when(mockMetaData.isHotDeploy()).thenReturn(false);
         when(mockMetaDataEntity.getDeployToJvms()).thenReturn(false);
-        when(Config.mockResourceService.getMetaData(anyString())).thenReturn(mockMetaData);
+        when(Config.mockApplicationService.getApplication(anyString())).thenReturn(mockApp);
+        when(Config.mockResourceService.getTokenizedMetaData(anyString(), any(Application.class), anyString())).thenReturn(mockMetaData);
 
         groupServiceRest.generateAndDeployGroupAppFile("test-group-name", "test.properties", "test-app-name", mockAuthUser, "test-host-name");
     }

--- a/jwala-webservices/src/test/java/com/cerner/jwala/ws/rest/v1/service/group/impl/GroupServiceImplDeployTest.java
+++ b/jwala-webservices/src/test/java/com/cerner/jwala/ws/rest/v1/service/group/impl/GroupServiceImplDeployTest.java
@@ -225,7 +225,7 @@ public class GroupServiceImplDeployTest {
         when(mockMetaData.getEntity()).thenReturn(mockEntity);
         when(mockMetaData.isHotDeploy()).thenReturn(false);
         when(Config.mockApplicationService.getApplication(anyString())).thenReturn(mockApp);
-        when(Config.mockResourceService.getTokenizedMetaData(anyString(), any(Application.class), anyString())).thenReturn(mockMetaData);
+        when(Config.mockResourceService.getMetaData(anyString())).thenReturn(mockMetaData);
         when(Config.mockGroupService.deployGroupAppTemplate(anyString(), anyString(), any(Application.class), any(Jvm.class))).thenReturn(new CommandOutput(new ExecReturnCode(0), "SUCCESS", ""));
 
         Response returnResponse = groupServiceRest.generateAndDeployGroupAppFile("testGroup", "hct.xml", "testApp", mockAuthUser, null);
@@ -299,7 +299,7 @@ public class GroupServiceImplDeployTest {
         when(mockEntity.getTarget()).thenReturn("testApp");
         when(mockMetaData.isHotDeploy()).thenReturn(false);
         when(Config.mockApplicationService.getApplication(anyString())).thenReturn(mockApp);
-        when(Config.mockResourceService.getTokenizedMetaData(anyString(), any(Application.class), anyString())).thenReturn(mockMetaData);
+        when(Config.mockResourceService.getMetaData(anyString())).thenReturn(mockMetaData);
         Response returnResponse = groupServiceRest.generateAndDeployGroupAppFile("testGroup", "hct.xml", "testApp", mockAuthUser, null);
         assertEquals(200, returnResponse.getStatus());
 
@@ -332,7 +332,7 @@ public class GroupServiceImplDeployTest {
         when(mockMetaData.isHotDeploy()).thenReturn(false);
         when(mockMetaDataEntity.getDeployToJvms()).thenReturn(false);
         when(Config.mockApplicationService.getApplication(anyString())).thenReturn(mockApp);
-        when(Config.mockResourceService.getTokenizedMetaData(anyString(), any(Application.class), anyString())).thenReturn(mockMetaData);
+        when(Config.mockResourceService.getMetaData(anyString())).thenReturn(mockMetaData);
 
         groupServiceRest.generateAndDeployGroupAppFile("test-group-name", "test.properties", "test-app-name", mockAuthUser, "test-host-name");
     }

--- a/jwala-webservices/src/test/java/com/cerner/jwala/ws/rest/v1/service/group/impl/GroupServiceRestImplTest.java
+++ b/jwala-webservices/src/test/java/com/cerner/jwala/ws/rest/v1/service/group/impl/GroupServiceRestImplTest.java
@@ -7,6 +7,7 @@ import com.cerner.jwala.common.domain.model.id.Identifier;
 import com.cerner.jwala.common.domain.model.jvm.Jvm;
 import com.cerner.jwala.common.domain.model.jvm.JvmControlOperation;
 import com.cerner.jwala.common.domain.model.jvm.JvmState;
+import com.cerner.jwala.common.domain.model.resource.ResourceContent;
 import com.cerner.jwala.common.domain.model.resource.ResourceGroup;
 import com.cerner.jwala.common.domain.model.resource.ResourceIdentifier;
 import com.cerner.jwala.common.domain.model.resource.ResourceTemplateMetaData;
@@ -492,6 +493,7 @@ public class GroupServiceRestImplTest {
         when(mockMetaData.getContentType()).thenReturn(MediaType.TEXT_PLAIN);
         when(mockMetaData.getDeployFileName()).thenReturn("httpd.conf");
         when(mockMetaData.getDeployPath()).thenReturn("/some/test/path");
+        when(mockMetaData.isHotDeploy()).thenReturn(false);
 
         Set<WebServer> wsSet = new HashSet<>();
         wsSet.add(mockWebServer);
@@ -503,7 +505,7 @@ public class GroupServiceRestImplTest {
         when(mockWebServerService.getResourceTemplate(anyString(), anyString(), anyBoolean(), any(ResourceGroup.class))).thenReturn(httpdConfTemplateContent);
         when(mockResourceService.updateResourceMetaData(any(ResourceIdentifier.class), anyString(), anyString())).thenReturn(rawMetaData);
         when(mockResourceService.getTokenizedMetaData(anyString(), Matchers.anyObject(), anyString())).thenReturn(mockMetaData);
-//        when(mockWebServerControlService.secureCopyFile(anyString(), anyString(), anyString(), anyString())).thenReturn(new CommandOutput(new ExecReturnCode(0), "SUCCESS",""));
+        when(mockResourceService.getResourceContent(any(ResourceIdentifier.class))).thenReturn(new ResourceContent("{\"test\":\"meta data\"}", "test resource content"));
 
         Response response = groupServiceRest.generateAndDeployGroupWebServersFile(group.getName(), "httpd.conf", mockAuthenticatedUser);
         assertEquals(200, response.getStatus());

--- a/jwala-webservices/src/test/java/com/cerner/jwala/ws/rest/v1/service/group/impl/GroupServiceRestImplTest.java
+++ b/jwala-webservices/src/test/java/com/cerner/jwala/ws/rest/v1/service/group/impl/GroupServiceRestImplTest.java
@@ -794,7 +794,8 @@ public class GroupServiceRestImplTest {
         when(mockJvm.getHostName()).thenReturn(hostname);
         when(mockGroup.getJvms()).thenReturn(jvms);
         when(mockJvm.getState()).thenReturn(jvmState);
-        groupServiceRest.performGroupAppDeployToJvms("test-group", "test-file", mockAuthenticatedUser, mockGroup, "test-app", mockApplicationServiceRest, hostname);
+
+        groupServiceRest.performGroupAppDeployToJvms("test-group", "test-file", mockAuthenticatedUser, mockGroup, "test-app", mockApplicationServiceRest, hostname, false);
     }
 
     /**

--- a/jwala-webservices/src/test/java/com/cerner/jwala/ws/rest/v1/service/group/impl/GroupServiceRestImplTest.java
+++ b/jwala-webservices/src/test/java/com/cerner/jwala/ws/rest/v1/service/group/impl/GroupServiceRestImplTest.java
@@ -1,5 +1,6 @@
 package com.cerner.jwala.ws.rest.v1.service.group.impl;
 
+import com.cerner.jwala.common.domain.model.app.Application;
 import com.cerner.jwala.common.domain.model.group.Group;
 import com.cerner.jwala.common.domain.model.group.GroupControlOperation;
 import com.cerner.jwala.common.domain.model.id.Identifier;
@@ -14,8 +15,6 @@ import com.cerner.jwala.common.domain.model.webserver.WebServer;
 import com.cerner.jwala.common.domain.model.webserver.WebServerControlOperation;
 import com.cerner.jwala.common.domain.model.webserver.WebServerReachableState;
 import com.cerner.jwala.common.exception.InternalErrorException;
-import com.cerner.jwala.common.exec.CommandOutput;
-import com.cerner.jwala.common.exec.ExecReturnCode;
 import com.cerner.jwala.common.properties.ApplicationProperties;
 import com.cerner.jwala.common.request.group.AddJvmsToGroupRequest;
 import com.cerner.jwala.common.request.group.CreateGroupRequest;
@@ -64,9 +63,11 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.Charset;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import static org.junit.Assert.*;
 import static org.mockito.Matchers.any;
@@ -777,7 +778,9 @@ public class GroupServiceRestImplTest {
     public void testGenerateAndDeployGroupAppFileFail() throws IOException {
         when(mockGroupService.getGroup(anyString())).thenReturn(mockGroup);
         when(mockGroupService.getGroupAppResourceTemplateMetaData(anyString(), anyString())).thenReturn("anyString");
-        when(mockResourceService.getMetaData(anyString())).thenThrow(new IOException("Cannot parse meta data: \"anyString\""));
+        Application mockApp = mock(Application.class);
+        when(mockApplicationService.getApplication(anyString())).thenReturn(mockApp);
+        when(mockResourceService.getTokenizedMetaData(anyString(), any(Application.class), anyString())).thenThrow(new IOException("Cannot parse meta data: \"anyString\""));
         groupServiceRest.generateAndDeployGroupAppFile("test-group", "anyFile.txt", "testApp", mockAuthenticatedUser, "anyHost");
     }
 

--- a/jwala-webservices/src/test/java/com/cerner/jwala/ws/rest/v1/service/group/impl/GroupServiceRestImplTest.java
+++ b/jwala-webservices/src/test/java/com/cerner/jwala/ws/rest/v1/service/group/impl/GroupServiceRestImplTest.java
@@ -68,7 +68,6 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.concurrent.ExecutorService;
 
 import static org.junit.Assert.*;
 import static org.mockito.Matchers.any;
@@ -157,9 +156,6 @@ public class GroupServiceRestImplTest {
     private ApplicationService mockApplicationService;
 
     @Mock
-    private ExecutorService mockExecutorService;
-
-    @Mock
     private WebServerControlService mockWebServerControlService;
 
     @Mock
@@ -211,11 +207,6 @@ public class GroupServiceRestImplTest {
         mockResourceService = mock(ResourceService.class);
         mockGroupService = mock(GroupService.class);
         mockBinaryDistributionService = mock(BinaryDistributionService.class);
-
-        groupServiceRest = new GroupServiceRestImpl(mockGroupService, mockResourceService, mockGroupControlService,
-                mockGroupJvmControlService, mockGroupWSControlService, mockJvmService, mockWebServerService,
-                mockApplicationService, applicationServiceRest, mockWebServerServiceRest);
-
 
         final WebServerServiceRest webServerServiceRest = new WebServerServiceRestImpl(mockWebServerService, mockWebServerControlService, mockWebServerCommandService,  mockResourceService, mockGroupService, mockBinaryDistributionService, mockHistoryFacadeService);
 
@@ -782,7 +773,7 @@ public class GroupServiceRestImplTest {
         when(mockGroupService.getGroupAppResourceTemplateMetaData(anyString(), anyString())).thenReturn("anyString");
         Application mockApp = mock(Application.class);
         when(mockApplicationService.getApplication(anyString())).thenReturn(mockApp);
-        when(mockResourceService.getTokenizedMetaData(anyString(), any(Application.class), anyString())).thenThrow(new IOException("Cannot parse meta data: \"anyString\""));
+        when(mockResourceService.getMetaData(anyString())).thenThrow(new IOException("Cannot parse meta data: \"anyString\""));
         groupServiceRest.generateAndDeployGroupAppFile("test-group", "anyFile.txt", "testApp", mockAuthenticatedUser, "anyHost");
     }
 


### PR DESCRIPTION
Add a new meta data attribute, hotDeploy, to deploy a resource to a running JVM or Web Server.

This functionality is only supported from the Resources UI and the specific REST APIs supporting the Resources UI.