### PR TITLE
Fix bug where elements overlap each other when their column width is

### DIFF
--- a/jwala-webapp/src/main/webapp/resources/css/adjustable-table-col.css
+++ b/jwala-webapp/src/main/webapp/resources/css/adjustable-table-col.css
@@ -3,15 +3,15 @@ table.adj-col {
     border-collapse: collapse !important;
 }
 
-th.adj-col {
+table.adj-col th {
     border-left: 1px solid rgb(230, 230, 230) !important;
     overflow: hidden !important;
     white-space: nowrap !important;
     padding: 3px 18px 3px 3px !important;
 }
 
-td.adj-col {
-    border-left: 1px solid rgb(230, 230, 230) !important;
+table.adj-col td {
+    border-left: 1px solid rgb(230, 230, 230);
     overflow: hidden !important;
     white-space: nowrap !important;
     padding-right: 1px !important;

--- a/jwala-webapp/src/main/webapp/resources/css/react/generic-components/default/simple-datatable.css
+++ b/jwala-webapp/src/main/webapp/resources/css/react/generic-components/default/simple-datatable.css
@@ -35,3 +35,7 @@ table.simple-data-table td > div > a {
 table.simple-data-table td > div > a:hover {
     color:#4585C5;
 }
+
+table.simple-data-table td {
+    border-left: none !important;
+}

--- a/jwala-webapp/src/main/webapp/resources/js/react/group-operations/WebServerControlPanelWidget.js
+++ b/jwala-webapp/src/main/webapp/resources/js/react/group-operations/WebServerControlPanelWidget.js
@@ -41,16 +41,13 @@ var WebServerControlPanelWidget = React.createClass({
                              disabledTitle="Only users with admin role can access this feature"/>
 
                     <button ref="httpdConfBtn" className="button-link anchor-font-style">httpd.conf</button>
-
-                    <a target="_blank" ref="statusLink" href={"https://" + this.props.data.host + ":" + this.props.data.httpsPort
-                            + jwalaVars.loadBalancerStatusMount}>status</a>
-
+                    <button ref="statusLinkBtn" className="button-link anchor-font-style">status</button>
                </div>
     },
 
     componentDidMount: function() {
         $(this.refs.httpdConfBtn.getDOMNode()).click(this.onClickHttpdConf);
-        $(this.refs.statusLink.getDOMNode()).click(this.onClickStatusLink);
+        $(this.refs.statusLinkBtn.getDOMNode()).click(this.onClickStatusLink);
     },
 
     webServerStart: function() {
@@ -111,7 +108,8 @@ var WebServerControlPanelWidget = React.createClass({
     },
 
     onClickStatusLink: function(e) {
-        return e.stopPropagation();
+        let statusUrl = "https://" + this.props.data.host + ":" + this.props.data.httpsPort + jwalaVars.loadBalancerStatusMount
+        window.open(statusUrl);
     },
 
     /**

--- a/jwala-webapp/src/main/webapp/resources/js/resizableTblColPlugin.js
+++ b/jwala-webapp/src/main/webapp/resources/js/resizableTblColPlugin.js
@@ -93,8 +93,6 @@
             $(self[idx]).find("tbody").mouseleave(onTbodyMouseLeave);
 
             $(self[idx]).addClass("adj-col");
-            $(self[idx]).find("thead th").addClass("adj-col");
-            $(self[idx]).find("tbody td").addClass("adj-col");
         });
     }
 


### PR DESCRIPTION
resized

Details of the fix:

- Change css in a manner that the td element overflow is set without adding a class to each individual td element. This primarily fixes the problem described above since for some reason adding adj-col in the TDs of the child tables does not work as expected. In addition, not adding a class on each element is more optimal.
- Change the status link to use the button element so that it will not
  overlap the button beside it when the column where it is in is shrunk