### PR TITLE
Error Message on clicking show details should display detailed error message instead of [object object]

### DIFF
--- a/jwala-integration-test/src/test/java/com/cerner/jwala/ui/selenium/JwalaChromeTestSuite.java
+++ b/jwala-integration-test/src/test/java/com/cerner/jwala/ui/selenium/JwalaChromeTestSuite.java
@@ -30,9 +30,9 @@ import java.util.concurrent.TimeUnit;
 @RunWith(Suite.class)
 @Suite.SuiteClasses({PreFlightTest.class, LoginTest.class, GroupCreateTest.class, JvmCreateTest.class, WebServerCreateTest.class,
         AppCreateTest.class, ResourceTopologyTest.class, UploadResourceTest.class, AddExternalProperty.class,
-        ModifyExternalPropertyResource.class, DeleteExternalProperty.class, HistoryTablePopupTest.class, AppDeleteTest.class,
-        JvmOperationsPageDeleteTest.class, WebServerOperationsPageDelete.class, WebServerCreateTest.class, WebServerDeleteTest.class,
-        JvmCreateTest.class, JvmDeleteTest.class, GroupDeleteTest.class, LogoutTest.class})
+        ModifyExternalPropertyResource.class, DeleteExternalProperty.class, ResourceDeployTest.class, HistoryTablePopupTest.class,
+        AppDeleteTest.class, JvmOperationsPageDeleteTest.class, WebServerOperationsPageDelete.class, WebServerCreateTest.class,
+        WebServerDeleteTest.class, JvmCreateTest.class, JvmDeleteTest.class, GroupDeleteTest.class, LogoutTest.class})
 public class JwalaChromeTestSuite extends TestSuite {
 
     private static final String WEBDRIVER_CHROME_DRIVER = "webdriver.chrome.driver";

--- a/jwala-integration-test/src/test/java/com/cerner/jwala/ui/selenium/testsuite/JwalaTest.java
+++ b/jwala-integration-test/src/test/java/com/cerner/jwala/ui/selenium/testsuite/JwalaTest.java
@@ -2,8 +2,10 @@ package com.cerner.jwala.ui.selenium.testsuite;
 
 import com.cerner.jwala.ui.selenium.TestSuite;
 import org.openqa.selenium.By;
+import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.interactions.Actions;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.support.ui.FluentWait;
 import org.openqa.selenium.support.ui.WebDriverWait;
@@ -67,6 +69,20 @@ public class JwalaTest {
         new WebDriverWait(driver, hideTimeout)
                 .until(ExpectedConditions.numberOfElementsToBe(
                         By.xpath("//div[contains(@class, 'AppBusyScreen') and contains(@class, 'show')]"), 0));
+    }
+
+    protected void rightClick(final By by) {
+        final Actions action = new Actions(driver).contextClick(driver.findElement(by));
+        action.build().perform();
+    }
+
+    protected boolean isElementExists(final String xPath) {
+        try {
+            driver.findElement(By.xpath(xPath));
+        } catch (final NoSuchElementException e) {
+            return false;
+        }
+        return true;
     }
 
 }

--- a/jwala-integration-test/src/test/java/com/cerner/jwala/ui/selenium/testsuite/configuration/resources/ResourceDeployTest.java
+++ b/jwala-integration-test/src/test/java/com/cerner/jwala/ui/selenium/testsuite/configuration/resources/ResourceDeployTest.java
@@ -1,0 +1,70 @@
+package com.cerner.jwala.ui.selenium.testsuite.configuration.resources;
+
+import com.cerner.jwala.ui.selenium.testsuite.JwalaTest;
+import org.junit.*;
+import org.openqa.selenium.By;
+import org.openqa.selenium.Keys;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.WebDriverWait;
+
+import static org.junit.Assert.assertFalse;
+
+/**
+ * Tests resource deployment scenarios
+ *
+ * Created by Jedd on 5/12/2017
+ */
+public class ResourceDeployTest extends JwalaTest {
+
+    private static final String GROUP_NAME_1 = "zGroup1-" + CURRENT_TIME_MILLIS;
+    private static final String JVM_NAME = "zJvm-" + CURRENT_TIME_MILLIS;
+    private static final String TEMPLATE_NAME = "invalid-" + CURRENT_TIME_MILLIS + ".tpl";
+
+    @Before
+    public void init() {
+        clickTab("Configuration");
+        clickTab("Resources");
+
+        final WebElement groupNode = clickTreeItemExpandCollapseIcon(GROUP_NAME_1);
+        clickTreeItemExpandCollapseIcon(groupNode, "JVMs");
+        driver.findElement(By.xpath("//span[text()='" + JVM_NAME + "']")).click();
+        driver.findElement(By.xpath("//span[contains(@class, 'ui-icon-plusthick') and @title='create']")).click();
+        driver.switchTo().activeElement().sendKeys(TEMPLATE_NAME);
+        driver.switchTo().activeElement().sendKeys(Keys.TAB);
+        driver.switchTo().activeElement().sendKeys("any");
+
+        driver.findElement(By.xpath("//input[@type='file']"))
+                .sendKeys(this.getClass().getClassLoader().getResource("selenium/invalid.tpl").getPath()
+                        .replaceFirst("/", ""));
+
+        driver.findElement(By.xpath("//span[text()='Ok']")).click();
+    }
+
+    /**
+     * Deploys an invalid resource and expects an error dialog box to be shown without the details shown
+     * @throws InterruptedException
+     */
+    @Test
+    public void testDeployInvalidJvmResource() throws InterruptedException {
+        rightClick(By.xpath("//span[text()='" + TEMPLATE_NAME + "']"));
+        driver.findElement(By.xpath("//span[text()='deploy']")).click();
+        driver.findElement(By.xpath("//span[text()='Yes']")).click();
+        webDriverWait.until(ExpectedConditions.visibilityOf(driver.findElement(By.xpath("//span[text()='ERROR']"))));
+
+        assertFalse(isElementExists("//button[text()='Hide Details']"));
+
+        driver.findElement(By.xpath("//span[text()='Ok']")).click();
+    }
+
+    @After
+    public void destroy() {
+        driver.findElement(By.xpath("//li/span[text()='" + TEMPLATE_NAME + "']/preceding-sibling::input[@type='checkbox']")).click();
+        driver.findElement(By.xpath("//span[contains(@class, 'ui-icon-trash') and @title='delete']")).click();
+        new WebDriverWait(driver, 10).until(ExpectedConditions
+                .numberOfElementsToBe(
+                        By.xpath("//b[text()='Are you sure you want to delete the selected resource template(s) ?']"), 1));
+        driver.switchTo().activeElement().sendKeys(Keys.ENTER);
+    }
+
+}

--- a/jwala-integration-test/src/test/resources/selenium/invalid.tpl
+++ b/jwala-integration-test/src/test/resources/selenium/invalid.tpl
@@ -1,0 +1,3 @@
+# This file is invalid when processed through the groovy template engine because of the dollar sign and the curly brace
+# that comes after this comment
+${

--- a/jwala-webapp/src/main/webapp/resources/js/error-alert.js
+++ b/jwala-webapp/src/main/webapp/resources/js/error-alert.js
@@ -46,6 +46,14 @@ $.extend({ errorAlert: function (message, dlgTitle, modal, content) {
 
             var detailsHtml = "";
             if (content && content !== "") {
+            let details = content;
+                 if(!Array.isArray(content)){
+                 details = new Array(content.length);
+                 for(let key in content){
+                 details.push(content[key]);
+                 }
+                 }
+                content = details;
                 var showErrorDetails = "$('.showErrorDetails').hide();$('.hideErrorDetails').show();$('.stackTrace').show()";
                 var hideErrorDetails = "$('.showErrorDetails').show();$('.hideErrorDetails').hide();$('.stackTrace').hide()";
                 detailsHtml = "<br><br><div style='width:100%;text-align:left'><button class='showErrorDetails' onClick="

--- a/jwala-webapp/src/main/webapp/resources/js/error-alert.js
+++ b/jwala-webapp/src/main/webapp/resources/js/error-alert.js
@@ -45,15 +45,7 @@ $.extend({ errorAlert: function (message, dlgTitle, modal, content) {
             }
 
             var detailsHtml = "";
-            if (content && content !== "") {
-                let details = content;
-                if (!Array.isArray(content)) {
-                    details = new Array(content.length);
-                    for (let key in content) {
-                        details.push(content[key] +"<br/>");
-                    }
-                }
-                content = details;
+            if (content && content !== "" && Array.isArray(content)) {
                 var showErrorDetails = "$('.showErrorDetails').hide();$('.hideErrorDetails').show();$('.stackTrace').show()";
                 var hideErrorDetails = "$('.showErrorDetails').show();$('.hideErrorDetails').hide();$('.stackTrace').hide()";
                 detailsHtml = "<br><br><div style='width:100%;text-align:left'><button class='showErrorDetails' onClick="

--- a/jwala-webapp/src/main/webapp/resources/js/error-alert.js
+++ b/jwala-webapp/src/main/webapp/resources/js/error-alert.js
@@ -45,7 +45,7 @@ $.extend({ errorAlert: function (message, dlgTitle, modal, content) {
             }
 
             var detailsHtml = "";
-            if (content && content !== "" && Array.isArray(content)) {
+            if (Array.isArray(content)) {
                 var showErrorDetails = "$('.showErrorDetails').hide();$('.hideErrorDetails').show();$('.stackTrace').show()";
                 var hideErrorDetails = "$('.showErrorDetails').show();$('.hideErrorDetails').hide();$('.stackTrace').hide()";
                 detailsHtml = "<br><br><div style='width:100%;text-align:left'><button class='showErrorDetails' onClick="

--- a/jwala-webapp/src/main/webapp/resources/js/error-alert.js
+++ b/jwala-webapp/src/main/webapp/resources/js/error-alert.js
@@ -46,13 +46,13 @@ $.extend({ errorAlert: function (message, dlgTitle, modal, content) {
 
             var detailsHtml = "";
             if (content && content !== "") {
-            let details = content;
-                 if(!Array.isArray(content)){
-                 details = new Array(content.length);
-                 for(let key in content){
-                 details.push(content[key]);
-                 }
-                 }
+                let details = content;
+                if (!Array.isArray(content)) {
+                    details = new Array(content.length);
+                    for (let key in content) {
+                        details.push(content[key]);
+                    }
+                }
                 content = details;
                 var showErrorDetails = "$('.showErrorDetails').hide();$('.hideErrorDetails').show();$('.stackTrace').show()";
                 var hideErrorDetails = "$('.showErrorDetails').show();$('.hideErrorDetails').hide();$('.stackTrace').hide()";

--- a/jwala-webapp/src/main/webapp/resources/js/error-alert.js
+++ b/jwala-webapp/src/main/webapp/resources/js/error-alert.js
@@ -50,7 +50,7 @@ $.extend({ errorAlert: function (message, dlgTitle, modal, content) {
                 if (!Array.isArray(content)) {
                     details = new Array(content.length);
                     for (let key in content) {
-                        details.push(content[key]);
+                        details.push(content[key] +"<br/>");
                     }
                 }
                 content = details;

--- a/jwala-webapp/src/main/webapp/resources/js/react/ResourcePane.js
+++ b/jwala-webapp/src/main/webapp/resources/js/react/ResourcePane.js
@@ -166,7 +166,7 @@ var ResourcePane = React.createClass({
         }
     },
     displayDeployErrorMessage: function(response){
-        $.errorAlert(ResourcePane.parseDetailedErrorMsg(response, ResourcePane.DEFAULT_DEPLOY_ERR_MSG), "", undefined, response.responseJSON.content);
+        $.errorAlert(ResourcePane.parseDetailedErrorMsg(response, ResourcePane.DEFAULT_DEPLOY_ERR_MSG), "");
     },
     deployResourceCallback: function() {
         var data = this.state.data;

--- a/jwala-webapp/src/main/webapp/resources/js/react/ResourcePane.js
+++ b/jwala-webapp/src/main/webapp/resources/js/react/ResourcePane.js
@@ -166,7 +166,7 @@ var ResourcePane = React.createClass({
         }
     },
     displayDeployErrorMessage: function(response){
-        $.errorAlert(ResourcePane.parseDetailedErrorMsg(response, ResourcePane.DEFAULT_DEPLOY_ERR_MSG), "");
+        $.errorAlert(ResourcePane.parseDetailedErrorMsg(response, ResourcePane.DEFAULT_DEPLOY_ERR_MSG), "", undefined, response.responseJSON.content);
     },
     deployResourceCallback: function() {
         var data = this.state.data;


### PR DESCRIPTION
In case, the validation of resource file fails, the show details button on clicking displays [object object], this has been changed to display detailed error message.