### PR TITLE
update JvmStateReceiverAdapter to be backwards compatible with older ReportingLifeCycleListener

### DIFF
--- a/jwala-services/src/main/java/com/cerner/jwala/service/jvm/state/JvmStateReceiverAdapter.java
+++ b/jwala-services/src/main/java/com/cerner/jwala/service/jvm/state/JvmStateReceiverAdapter.java
@@ -79,14 +79,14 @@ public class JvmStateReceiverAdapter extends ReceiverAdapter {
             return null;
         }
 
-        final Object initialKey = keys.iterator().next();
-        if (initialKey instanceof String) {
+        if (serverInfoMap.containsKey(STATE_KEY)) {
             // convert the LifecycleState to the JvmState
             return LIFECYCLE_JWALA_JVM_STATE_REF_MAP.get(serverInfoMap.get(STATE_KEY));
         }
 
         // assume the key is ReportingJmsMessageKey, in which case the value is already returned as a string JvmState
         try {
+            final Object initialKey = keys.iterator().next();
             final Field idKey = initialKey.getClass().getDeclaredField(STATE_KEY);
             final String jvmStateString = (String) serverInfoMap.get(idKey.get(initialKey));
             return JvmState.valueOf(jvmStateString);
@@ -122,13 +122,13 @@ public class JvmStateReceiverAdapter extends ReceiverAdapter {
             return null;
         }
 
-        final Object initialKey = keys.iterator().next();
-        if (initialKey instanceof String) {
+        if (serverInfoMap.containsKey(key)) {
             return (String) serverInfoMap.get(key);
         }
 
         // assume the key is ReportingJmsMessageKey
         try {
+            final Object initialKey = keys.iterator().next();
             final Field idKey = initialKey.getClass().getDeclaredField(key);
             return (String) serverInfoMap.get(idKey.get(initialKey));
         } catch (NoSuchFieldException e) {

--- a/jwala-services/src/main/java/com/cerner/jwala/service/jvm/state/JvmStateReceiverAdapter.java
+++ b/jwala-services/src/main/java/com/cerner/jwala/service/jvm/state/JvmStateReceiverAdapter.java
@@ -6,6 +6,7 @@ import com.cerner.jwala.common.domain.model.jvm.JvmState;
 import com.cerner.jwala.persistence.service.JvmPersistenceService;
 import com.cerner.jwala.service.jvm.JvmStateService;
 import org.apache.catalina.LifecycleState;
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.math.NumberUtils;
 import org.jgroups.Message;
@@ -74,7 +75,7 @@ public class JvmStateReceiverAdapter extends ReceiverAdapter {
 
         // first check if the key types are string
         final Set keys = serverInfoMap.keySet();
-        if (keys.isEmpty()) {
+        if (CollectionUtils.isEmpty(keys)) {
             return null;
         }
 
@@ -117,7 +118,7 @@ public class JvmStateReceiverAdapter extends ReceiverAdapter {
 
         // first check if the key types are string
         final Set keys = serverInfoMap.keySet();
-        if (keys.isEmpty()) {
+        if (CollectionUtils.isEmpty(keys)) {
             return null;
         }
 
@@ -131,10 +132,10 @@ public class JvmStateReceiverAdapter extends ReceiverAdapter {
             final Field idKey = initialKey.getClass().getDeclaredField(key);
             return (String) serverInfoMap.get(idKey.get(initialKey));
         } catch (NoSuchFieldException e) {
-            LOGGER.error("Failed to find key " + key +" as ReportingJmsMessageKey in message: {}", serverInfoMap, e);
+            LOGGER.error("Failed to find key {} as ReportingJmsMessageKey in message: {}", key, serverInfoMap, e);
             return null;
         } catch (IllegalAccessException e) {
-            LOGGER.error("Failed to convert " + key + " key to ReportingJmsMessageKey in message: {}", serverInfoMap, e);
+            LOGGER.error("Failed to convert {} key to ReportingJmsMessageKey in message: {}", key, serverInfoMap, e);
             return null;
         }
     }

--- a/jwala-services/src/main/java/com/cerner/jwala/service/jvm/state/JvmStateReceiverAdapter.java
+++ b/jwala-services/src/main/java/com/cerner/jwala/service/jvm/state/JvmStateReceiverAdapter.java
@@ -73,18 +73,19 @@ public class JvmStateReceiverAdapter extends ReceiverAdapter {
 
     private JvmState getJvmState(final Map serverInfoMap) {
 
-        // first check if the key types are string
+        // first check if the key types are String to support the latest version
         final Set keys = serverInfoMap.keySet();
         if (CollectionUtils.isEmpty(keys)) {
             return null;
         }
 
         if (serverInfoMap.containsKey(STATE_KEY)) {
-            // convert the LifecycleState to the JvmState
+            // the latest version sends the Tomcat Lifecycle State
+            // so we need to convert the Tomcat Lifecycle State to the JvmState
             return LIFECYCLE_JWALA_JVM_STATE_REF_MAP.get(serverInfoMap.get(STATE_KEY));
         }
 
-        // assume the key is ReportingJmsMessageKey, in which case the value is already returned as a string JvmState
+        // assume the message is from the initial version of the Jvm state reporter, in which case the value is already returned as a string JvmState
         try {
             final Object initialKey = keys.iterator().next();
             final Field idKey = initialKey.getClass().getDeclaredField(STATE_KEY);
@@ -116,7 +117,7 @@ public class JvmStateReceiverAdapter extends ReceiverAdapter {
 
     private String getStringFromMessageMap(final Map serverInfoMap, final String key) {
 
-        // first check if the key types are string
+        // check for a String key first to support the latest version
         final Set keys = serverInfoMap.keySet();
         if (CollectionUtils.isEmpty(keys)) {
             return null;
@@ -126,7 +127,7 @@ public class JvmStateReceiverAdapter extends ReceiverAdapter {
             return (String) serverInfoMap.get(key);
         }
 
-        // assume the key is ReportingJmsMessageKey
+        // assume the message is from the initial version of the JVM state reporter
         try {
             final Object initialKey = keys.iterator().next();
             final Field idKey = initialKey.getClass().getDeclaredField(key);

--- a/jwala-services/src/test/java/com/cerner/jwala/service/jvm/state/JvmStateReceiverAdapterTest.java
+++ b/jwala-services/src/test/java/com/cerner/jwala/service/jvm/state/JvmStateReceiverAdapterTest.java
@@ -61,6 +61,23 @@ public class JvmStateReceiverAdapterTest {
         verify(mockJvmStateService).updateState(eq(jvm), eq(JvmState.JVM_STOPPING), eq(StringUtils.EMPTY));
     }
 
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testReceiveReportingJmsMessageKey() throws Exception {
+        final Identifier<Jvm> jvmId = new Identifier<>("1");
+        Jvm jvm = new Jvm(jvmId, "jvm-name");
+
+        final Map<Object, Object> serverInfoMap = new HashMap();
+        serverInfoMap.put(ReportingJmsMessageTestKey.ID, "1");
+        serverInfoMap.put(ReportingJmsMessageTestKey.STATE, "JVM_STOPPING");
+
+        msg = new Message();
+        msg.setObject(serverInfoMap);
+
+        when (mockJvmPersistenceService.getJvm(jvmId)).thenReturn(jvm);
+        jvmStateReceiverAdapter.receive(msg);
+        verify(mockJvmStateService).updateState(eq(jvm), eq(JvmState.JVM_STOPPING), eq(StringUtils.EMPTY));
+    }
 
     @Test
     @SuppressWarnings("unchecked")
@@ -100,4 +117,19 @@ public class JvmStateReceiverAdapterTest {
         verify(mockJvmStateService, never()).updateState(eq(jvm), eq(JvmState.JVM_STOPPING), eq(StringUtils.EMPTY));
     }
 
+    private enum ReportingJmsMessageTestKey {
+        ID("id"),
+        STATE("state"),
+        NAME("name");
+
+        private final String key;
+
+        private ReportingJmsMessageTestKey(final String theKey) {
+            key = theKey;
+        }
+
+        public String getKey() {
+            return key;
+        }
+    }
 }


### PR DESCRIPTION
In the older versions of the ReportingLifeCycleListener the JVM state message came in the format of key/value pairs for the following info:
 - ID => ReportingJmsMessageKey/String
 - STATE => ReportingJmsMessageKey/String

And for the latest ReportingLifeCycleListener the JVM state message came in the format of:
 - ID => String/String
 - NAME => String/String
 - STATE => String/TomcatLifecycleState 

So, in older versions of jwala that are upgraded to the latest, the application JVMs will still send their state messages in the old format which is not handled by the latest JvmStateReceiverAdapter