### PR TITLE
Fix intermittent resource tab bug wherein add resource is not clickab…

### DIFF
--- a/jwala-integration-test/src/test/java/com/cerner/jwala/ui/selenium/testsuite/configuration/resources/AddExternalProperty.java
+++ b/jwala-integration-test/src/test/java/com/cerner/jwala/ui/selenium/testsuite/configuration/resources/AddExternalProperty.java
@@ -16,8 +16,11 @@ public class AddExternalProperty extends JwalaTest {
     public void addExternalProperties() {
         clickTab("Configuration");
         clickTab("Resources");
+
+        // Loads ext properties, screen is disable momentarily while loading so we need a waitClick (waits for element
+        // to be clickable before clicking) for the next click action
         driver.findElement(By.xpath("//span[text()='Ext Properties']")).click();
-        driver.findElement(By.xpath("//span[contains(@class, 'ui-icon-plusthick') and @title='create']")).click();
+        waitClick(By.xpath("//span[contains(@class, 'ui-icon-plusthick') and @title='create']"));
         driver.findElement(By.xpath("//input[@type='file']"))
                 .sendKeys(this.getClass().getClassLoader().getResource("selenium/test.properties").getPath()
                 .replaceFirst("/", ""));
@@ -25,7 +28,7 @@ public class AddExternalProperty extends JwalaTest {
         new WebDriverWait(driver, 10).until(ExpectedConditions.numberOfElementsToBe(By.xpath("//li/span[text()='ext.properties']"), 1));
 
         // Check if the mechanism that prevents users from adding another external properties resource is working
-        driver.findElement(By.xpath("//span[contains(@class, 'ui-icon-plusthick') and @title='create']")).click();
+        waitClick(By.xpath("//span[contains(@class, 'ui-icon-plusthick') and @title='create']"));
         new WebDriverWait(driver, 10).until(ExpectedConditions.numberOfElementsToBe(
                 By.xpath("//span[text()='Only one external properties file can be uploaded. Any existing ones will be overwritten.']"), 1));
         driver.switchTo().activeElement().sendKeys(Keys.ESCAPE);

--- a/jwala-integration-test/src/test/java/com/cerner/jwala/ui/selenium/testsuite/configuration/resources/DeleteExternalProperty.java
+++ b/jwala-integration-test/src/test/java/com/cerner/jwala/ui/selenium/testsuite/configuration/resources/DeleteExternalProperty.java
@@ -16,7 +16,11 @@ public class DeleteExternalProperty extends JwalaTest {
     public void delExternalProperties() {
         clickTab("Configuration");
         clickTab("Resources");
-        driver.findElement(By.xpath("//li/span[text()='ext.properties']/preceding-sibling::input[@type='checkbox']")).click();
+
+        // If not coming from add ext property, this code makes sure ext properties is the currently selected
+        // Topology node
+        driver.findElement(By.xpath("//span[text()='Ext Properties']")).click();
+        waitClick(By.xpath("//li/span[text()='ext.properties']/preceding-sibling::input[@type='checkbox']"));
         driver.findElement(By.xpath("//span[contains(@class, 'ui-icon-trash') and @title='delete']")).click();
         new WebDriverWait(driver, 10).until(ExpectedConditions.numberOfElementsToBe(By.xpath("//b[text()='Are you sure you want to delete the property file ?']"), 1));
         driver.switchTo().activeElement().sendKeys(Keys.ENTER);

--- a/jwala-integration-test/src/test/java/com/cerner/jwala/ui/selenium/testsuite/configuration/resources/ModifyExternalPropertyResource.java
+++ b/jwala-integration-test/src/test/java/com/cerner/jwala/ui/selenium/testsuite/configuration/resources/ModifyExternalPropertyResource.java
@@ -17,8 +17,11 @@ public class ModifyExternalPropertyResource extends JwalaTest {
     public void testModifyExtPropResource() {
         clickTab("Configuration");
         clickTab("Resources");
+
+        // Loads ext properties, screen is disable momentarily while loading so we need a waitClick (waits for element
+        // to be clickable before clicking) for the next click action
         driver.findElement(By.xpath("//span[text()='Ext Properties']")).click();
-        driver.findElement(By.xpath("//li/span[text()='ext.properties']")).click();
+        waitClick(By.xpath("//li/span[text()='ext.properties']"));
         driver.findElement(By.xpath("//div[contains(@class, 'CodeMirror') and contains(@class, 'cm-s-default')]")).click();
         driver.switchTo().activeElement().sendKeys(TEST_STR);
         driver.findElement(By.xpath("//span[contains(@class, 'ui-icon-disk') and @title='Save']")).click();
@@ -28,7 +31,7 @@ public class ModifyExternalPropertyResource extends JwalaTest {
         driver.findElement(By.xpath("//span[text()='Ext Properties']")).click();
         new WebDriverWait(driver, 10)
                 .until(ExpectedConditions.numberOfElementsToBe(By.xpath("//div[contains(@class, 'CodeMirror') and contains(@class, 'cm-s-default')]"), 0));
-        driver.findElement(By.xpath("//li/span[text()='ext.properties']")).click();
+        waitClick(By.xpath("//li/span[text()='ext.properties']"));
         new WebDriverWait(driver, 10).until(ExpectedConditions.numberOfElementsToBeMoreThan(By.xpath("//div[contains(.,'" + TEST_STR + "')]"), 0));
     }
 


### PR DESCRIPTION
This is a fix for the tests about external properties in the resource tab in wherein if the "Ext Properties" node is clicked the resource add button is momentarily disabled with a screen overlay (The gray thingy with the rotating gears) then executing a click on it makes Selenium throw an error stating that the "element is not clickable". The bug is intermittent and will only appear if the "Ext Properties" loading is delayed a little.