### PR TITLE
Replace remote.paths.instances with jvm tomcat media remote dir

### DIFF
--- a/jwala-common/src/main/java/com/cerner/jwala/common/domain/model/media/Media.java
+++ b/jwala-common/src/main/java/com/cerner/jwala/common/domain/model/media/Media.java
@@ -17,19 +17,19 @@ public class Media {
     private MediaType type;
     private Path localPath;
     private Path remoteDir;
-    private Path mediaDir;
+    private Path rootDir;
 
     public Media() {
     }
 
     public Media(final Long id, final String name, final MediaType type, final Path path, final Path remoteDir,
-                 final Path mediaDir) {
+                 final Path rootDir) {
         this.id = id;
         this.name = name;
         this.type = type;
         this.localPath = path;
         this.remoteDir = remoteDir;
-        this.mediaDir = mediaDir;
+        this.rootDir = rootDir;
     }
 
     public Long getId() {
@@ -77,13 +77,13 @@ public class Media {
     }
 
     @JsonSerialize(using = PathToStringSerializer.class)
-    public Path getMediaDir() {
-        return mediaDir;
+    public Path getRootDir() {
+        return rootDir;
     }
 
     @JsonDeserialize(using = StringToPathDeserializer.class)
-    public void setMediaDir(Path mediaDir) {
-        this.mediaDir = mediaDir;
+    public void setRootDir(Path rootDir) {
+        this.rootDir = rootDir;
     }
 
 }

--- a/jwala-common/src/main/java/com/cerner/jwala/common/properties/PropertyKeys.java
+++ b/jwala-common/src/main/java/com/cerner/jwala/common/properties/PropertyKeys.java
@@ -22,7 +22,6 @@ public enum PropertyKeys {
     PORT("ssh.port"),
     PRIVATE_KEY_FILE("ssh.privateKeyFile"),
     REMOTE_JAWALA_DATA_DIR("remote.jwala.data.dir"),
-    REMOTE_PATHS_INSTANCES_DIR("remote.paths.instances"),
     REMOTE_PATHS_TOMCAT_ROOT_CORE("remote.paths.tomcat.root.core"),
     REMOTE_SCRIPT_DIR("remote.commands.user-scripts"),
     SCRIPTS_PATH("commands.scripts-path"),

--- a/jwala-common/src/test/java/com/cerner/jwala/common/domain/model/ResourceTemplateMetaDataTest.java
+++ b/jwala-common/src/test/java/com/cerner/jwala/common/domain/model/ResourceTemplateMetaDataTest.java
@@ -19,7 +19,7 @@ public class ResourceTemplateMetaDataTest {
             "    \"templateName\": \"SetenvBatTemplate.tpl\",\n" +
             "    \"contentType\": \"text/plain\",\n" +
             "    \"deployFileName\": \"setenv.bat\",\n" +
-            "    \"deployPath\": \"${vars.'remote.paths.instances'}/${jvm.jvmName}/bin\",\n" +
+            "    \"deployPath\": \"${jvm.tomcatMedia.mediaDir}/${jvm.jvmName}/bin\",\n" +
             "    \"entity\": {\n" +
             "        \"type\": \"GROUPED_JVMS\",\n" +
             "        \"group\": \"HEALTH CHECK 4.0\",\n" +
@@ -31,7 +31,7 @@ public class ResourceTemplateMetaDataTest {
             "}";
 
     private static final String EXPECTED_META_DATA_STR = "ResourceTemplateMetaData{templateName='SetenvBatTemplate.tpl', " +
-            "contentType=text/plain, deployFileName='setenv.bat', deployPath='${vars.'remote.paths.instances'}/${jvm.jvmName}/bin', " +
+            "contentType=text/plain, deployFileName='setenv.bat', deployPath='${jvm.tomcatMedia.mediaDir}/${jvm.jvmName}/bin', " +
             "entity=Entity{type='GROUPED_JVMS', group='HEALTH CHECK 4.0', target='HEALTH CHECK 4.0', parentName='null', deployToJvms=true}, " +
             "unpack=false, overwrite=true, hotDeploy=false}";
 

--- a/jwala-common/src/test/resources/properties/reload/vars.properties
+++ b/jwala-common/src/test/resources/properties/reload/vars.properties
@@ -1,6 +1,5 @@
 reload.property=reloaded
 net.stop.sleep.time.seconds=5
-remote.paths.instances=d:/jwala/app/instances
 string.property=string property
 integer.property=5
 boolean.property=true

--- a/jwala-common/src/test/resources/properties/vars.properties
+++ b/jwala-common/src/test/resources/properties/vars.properties
@@ -1,5 +1,4 @@
 net.stop.sleep.time.seconds=5
-remote.paths.instances=d:/jwala/app/instances
 string.property=string property
 integer.property=5
 boolean.property=true

--- a/jwala-common/src/test/resources/vars.properties
+++ b/jwala-common/src/test/resources/vars.properties
@@ -1,5 +1,4 @@
 net.stop.sleep.time.seconds=5
-remote.paths.instances=d:/jwala/app/instances
 string.property=string property
 integer.property=5
 boolean.property=true

--- a/jwala-integration-test/src/test/postman/jwala-collection.postman_collection.json
+++ b/jwala-integration-test/src/test/postman/jwala-collection.postman_collection.json
@@ -1308,7 +1308,7 @@
 							"formdata": [
 								{
 									"key": "deployPath",
-									"value": "${vars['remote.paths.instances']}/${jvm.jvmName}/apache-tomcat-7.0.55/conf/stp/localhost",
+									"value": "${jvm.tomcatMedia.mediaDir}/${jvm.jvmName}/${jvm.tomcatMedia.rootDir}/conf/stp/localhost",
 									"type": "text",
 									"enabled": true
 								},
@@ -2993,7 +2993,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\r\n  \"deployPath\" : \"${vars.'remote.paths.instances'}/${jvm.jvmName}/${vars['remote.tomcat.dir.name']}/conf\",\r\n  \"templateName\" : \"server.xml.tpl\",\r\n  \"deployFileName\" : \"server.xml\",\r\n  \"contentType\" : \"application/xml\",\r\n  \"hotDeploy\":true,\r\n  \"entity\" : {\r\n    \"type\" : \"GROUPED_JVMS\",\r\n    \"group\" : \"Postman-Test-Group\",\r\n    \"target\" : \"Postman-Test-Group\"\r\n  }\r\n}"
+							"raw": "{\r\n  \"deployPath\" : \"${jvm.tomcatMedia.mediaDir}/${jvm.jvmName}/${jvm.tomcatMedia.rootDir}/conf\",\r\n  \"templateName\" : \"server.xml.tpl\",\r\n  \"deployFileName\" : \"server.xml\",\r\n  \"contentType\" : \"application/xml\",\r\n  \"hotDeploy\":true,\r\n  \"entity\" : {\r\n    \"type\" : \"GROUPED_JVMS\",\r\n    \"group\" : \"Postman-Test-Group\",\r\n    \"target\" : \"Postman-Test-Group\"\r\n  }\r\n}"
 						},
 						"description": ""
 					},
@@ -3138,7 +3138,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\r\n  \"deployPath\" : \"${vars.'remote.paths.instances'}/${jvm.jvmName}/${vars['remote.tomcat.dir.name']}/conf\",\r\n  \"templateName\" : \"server.xml.tpl\",\r\n  \"deployFileName\" : \"server.xml\",\r\n  \"contentType\" : \"application/xml\",\r\n  \"hotDeploy\":false,\r\n  \"entity\" : {\r\n    \"type\" : \"GROUPED_JVMS\",\r\n    \"group\" : \"Postman-Test-Group\",\r\n    \"target\" : \"Postman-Test-Group\"\r\n  }\r\n}"
+							"raw": "{\r\n  \"deployPath\" : \"${jvm.tomcatMedia.mediaDir}/${jvm.jvmName}/${jvm.tomcatMedia.rootDir}/conf\",\r\n  \"templateName\" : \"server.xml.tpl\",\r\n  \"deployFileName\" : \"server.xml\",\r\n  \"contentType\" : \"application/xml\",\r\n  \"hotDeploy\":false,\r\n  \"entity\" : {\r\n    \"type\" : \"GROUPED_JVMS\",\r\n    \"group\" : \"Postman-Test-Group\",\r\n    \"target\" : \"Postman-Test-Group\"\r\n  }\r\n}"
 						},
 						"description": ""
 					},
@@ -5239,7 +5239,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\r\n        \"templateName\":\"hctXmlTemplate.tpl\",\r\n        \"contentType\":\"text/xml\",\r\n        \"deployPath\":\"${vars.'remote.paths.instances'/${jvm.jvmName}/conf/stp/localhost\",\r\n        \"deployFileName\":\"hct.xml\",\r\n        \"entity\":{\r\n                \"type\":\"GROUPED_APPS\",\r\n                \"group\":\"HEALTH CHECK 4.0\",\r\n                \"target\":\"HEALTH-CHECK-4.0\"\r\n        }\r\n}"
+							"raw": "{\r\n        \"templateName\":\"hctXmlTemplate.tpl\",\r\n        \"contentType\":\"text/xml\",\r\n        \"deployPath\":\"${jvm.tomcatMedia.mediaDir}/${jvm.jvmName}/${jvm.tomcatMedia.rootDir}/conf/stp/localhost\",\r\n        \"deployFileName\":\"hct.xml\",\r\n        \"entity\":{\r\n                \"type\":\"GROUPED_APPS\",\r\n                \"group\":\"HEALTH CHECK 4.0\",\r\n                \"target\":\"HEALTH-CHECK-4.0\"\r\n        }\r\n}"
 						},
 						"description": ""
 					},
@@ -5278,7 +5278,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\r\n        \"templateName\":\"hctXmlTemplate.tpl\",\r\n        \"contentType\":\"text/xml\",\r\n        \"deployPath\":\"${vars.'remote.paths.instances'}/${jvm.jvmName}/conf/stp/localhost\",\r\n        \"deployFileName\":\"hct.xml\",\r\n        \"entity\":{\r\n                \"type\":\"GROUPED_APPS\",\r\n                \"group\":\"HEALTH CHECK 4.0\",\r\n                \"target\":\"HEALTH-CHECK-4.0\"\r\n        }\r\n}\r\n\r\n"
+							"raw": "{\r\n        \"templateName\":\"hctXmlTemplate.tpl\",\r\n        \"contentType\":\"text/xml\",\r\n        \"deployPath\":\"${jvm.tomcatMedia.mediaDir}/${jvm.jvmName}/${jvm.tomcatMedia.rootDir}/conf/stp/localhost\",\r\n        \"deployFileName\":\"hct.xml\",\r\n        \"entity\":{\r\n                \"type\":\"GROUPED_APPS\",\r\n                \"group\":\"HEALTH CHECK 4.0\",\r\n                \"target\":\"HEALTH-CHECK-4.0\"\r\n        }\r\n}\r\n\r\n"
 						},
 						"description": ""
 					},
@@ -5362,7 +5362,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\r\n    \"templateName\":\"CatalinaProperties.tpl\",\r\n    \"contentType\":\"text/plain\",\r\n    \"deployPath\":\"${vars.'remote.paths.instances'}/${jvm.jvmName}/conf\",\r\n    \"deployFileName\":\"catalina.properties\",\r\n    \"entity\":{\r\n        \"type\":\"GROUPED_JVMS\", \r\n        \"group\":\"HEALTH CHECK 4.0\",\r\n        \"target\":\"HEALTH CHECK 4.0\"\r\n    }\r\n}\r\n"
+							"raw": "{\r\n    \"templateName\":\"CatalinaProperties.tpl\",\r\n    \"contentType\":\"text/plain\",\r\n    \"deployPath\":\"${jvm.tomcatMedia.mediaDir}/${jvm.jvmName}/${jvm.tomcatMedia.rootDir}/conf\",\r\n    \"deployFileName\":\"catalina.properties\",\r\n    \"entity\":{\r\n        \"type\":\"GROUPED_JVMS\", \r\n        \"group\":\"HEALTH CHECK 4.0\",\r\n        \"target\":\"HEALTH CHECK 4.0\"\r\n    }\r\n}\r\n"
 						},
 						"description": ""
 					},

--- a/jwala-integration-test/src/test/resources/postman/hello.xml.json
+++ b/jwala-integration-test/src/test/resources/postman/hello.xml.json
@@ -1,6 +1,6 @@
 {
     "deployFileName":"hello.xml",
-    "deployPath":"${vars['remote.paths.instances']}/${jvm.jvmName}/apache-tomcat-7.0.55/conf/stp/localhost",
+    "deployPath":"${jvm.tomcatMedia.mediaDir}/${jvm.jvmName}/${jvm.tomcatMedia.rootDir}/conf/stp/localhost",
     "templateName":"hello.xml.tpl",
     "contentType":"text/xml",
     "entity":{

--- a/jwala-integration-test/src/test/resources/postman/linux/httpdconf.tpl
+++ b/jwala-integration-test/src/test/resources/postman/linux/httpdconf.tpl
@@ -35,10 +35,10 @@
 # least PidFile.
 #
 # Allow multiple httpd instances to run on the same host
-PidFile ${webServer.apacheHttpdMedia.remoteDir}/${webServer.apacheHttpdMedia.mediaDir}/logs/httpd-${webServer.name}.pid
+PidFile ${webServer.apacheHttpdMedia.remoteDir}/${webServer.apacheHttpdMedia.rootDir}/logs/httpd-${webServer.name}.pid
 #
 #ServerRoot ./
-ServerRoot "${webServer.apacheHttpdMedia.remoteDir}/${webServer.apacheHttpdMedia.mediaDir}"
+ServerRoot "${webServer.apacheHttpdMedia.remoteDir}/${webServer.apacheHttpdMedia.rootDir}"
 
 #
 # Mutex: Allows you to set the mutex mechanism and mutex file directory
@@ -520,7 +520,7 @@ DocumentRoot htdocs
 # ErrorLog "logs/error.log"
 # Use log file rotation:
 
-ErrorLog "|${webServer.apacheHttpdMedia.remoteDir}/${webServer.apacheHttpdMedia.mediaDir}/bin/rotatelogs -n 10 -l ${webServer.apacheHttpdMedia.remoteDir}/${webServer.apacheHttpdMedia.mediaDir}/logs/error-log-${webServer.name} 10M"
+ErrorLog "|${webServer.apacheHttpdMedia.remoteDir}/${webServer.apacheHttpdMedia.rootDir}/bin/rotatelogs -n 10 -l ${webServer.apacheHttpdMedia.remoteDir}/${webServer.apacheHttpdMedia.rootDir}/logs/error-log-${webServer.name} 10M"
 
 #
 # LogLevel: Control the number of messages logged to the error_log.
@@ -551,7 +551,7 @@ LogLevel warn
     #
     # CustomLog "logs/access.log" common
     # Use log file rotation:
-     CustomLog "|${webServer.apacheHttpdMedia.remoteDir}/${webServer.apacheHttpdMedia.mediaDir}/bin/rotatelogs -n 10 -l ${webServer.apacheHttpdMedia.remoteDir}/${webServer.apacheHttpdMedia.mediaDir}/logs/access-log-${webServer.name} 10M" common
+     CustomLog "|${webServer.apacheHttpdMedia.remoteDir}/${webServer.apacheHttpdMedia.rootDir}/bin/rotatelogs -n 10 -l ${webServer.apacheHttpdMedia.remoteDir}/${webServer.apacheHttpdMedia.rootDir}/logs/access-log-${webServer.name} 10M" common
 
     #
     # If you prefer a logfile with access, agent, and referer information

--- a/jwala-integration-test/src/test/resources/postman/server.xml.json
+++ b/jwala-integration-test/src/test/resources/postman/server.xml.json
@@ -1,7 +1,7 @@
 {
         "templateName":"server.xml.tpl",
         "contentType":"text/xml",
-        "deployPath":"${vars.'remote.paths.instances'}/${jvm.jvmName}/apache-tomcat-7.0.55/conf",
+        "deployPath":"${jvm.tomcatMedia.mediaDir}/${jvm.jvmName}/${jvm.tomcatMedia.rootDir}/conf",
         "deployFileName":"server.xml",
         "entity":{
            "type":"GROUPED_JVMS",

--- a/jwala-integration-test/src/test/resources/postman/setenv.bat.json
+++ b/jwala-integration-test/src/test/resources/postman/setenv.bat.json
@@ -1,7 +1,7 @@
 {
         "templateName":"setenv.tpl",
         "contentType":"text/plain",
-        "deployPath":"${vars.'remote.paths.instances'}/${jvm.jvmName}/apache-tomcat-7.0.55/bin",
+        "deployPath":"${jvm.tomcatMedia.mediaDir}/${jvm.jvmName}/${jvm.tomcatMedia.rootDir}/bin",
         "deployFileName":"setenv.bat",
         "entity":{
                 "type":"GROUPED_JVMS",

--- a/jwala-integration-test/src/test/resources/postman/setenv.bat.tpl
+++ b/jwala-integration-test/src/test/resources/postman/setenv.bat.tpl
@@ -1,7 +1,7 @@
 SET JAVA_HOME=${jvm.javaHome}
 SET JRE_HOME=%JAVA_HOME%\jre
 
-SET CATALINA_HOME=${vars['remote.paths.instances']}/${jvm.jvmName}/apache-tomcat-7.0.55
+SET CATALINA_HOME=${jvm.tomcatMedia.mediaDir}/${jvm.jvmName}/${jvm.tomcatMedia.rootDir}
 SET CATALINA_OPTS=-XX:PermSize=512m -XX:MaxPermSize=512m 
 
 SET PROPERTIES_ROOT_PATH=${vars['remote.jwala.data.dir']}\..\..\app\properties
@@ -10,7 +10,7 @@ SET STP_OPTS=-DPROPERTIES_ROOT_PATH=%PROPERTIES_ROOT_PATH%
 SET STP_PROPERTIES_DIR=${vars['remote.jwala.data.dir']}\..\..\app\properties
 SET STP_OPTS=%STP_OPTS% -DSTP_PROPERTIES_DIR=%STP_PROPERTIES_DIR%
 
-SET LOG_ROOT_DIR=${vars['remote.paths.instances']}/${jvm.jvmName}/apache-tomcat-7.0.55/logs
+SET LOG_ROOT_DIR=${jvm.tomcatMedia.mediaDir}/${jvm.jvmName}/${jvm.tomcatMedia.rootDir}/logs
 SET LOG_OPTS=-Dlog.root.dir=%LOG_ROOT_DIR%
 SET LOG_OPTS=%LOG_OPTS% -Dlog4j.configuration=log4j.xml -Dlog4j.debug=true
 

--- a/jwala-integration-test/src/test/resources/postman/setenv.sh.json
+++ b/jwala-integration-test/src/test/resources/postman/setenv.sh.json
@@ -1,5 +1,5 @@
 {
-  "deployPath" : "${vars.'remote.paths.instances'}/${jvm.jvmName}/apache-tomcat-7.0.55/bin",
+  "deployPath" : "${jvm.tomcatMedia.mediaDir}/${jvm.jvmName}/${jvm.tomcatMedia.rootDir}/bin",
   "templateName" : "SetenvShTemplate.tpl",
   "deployFileName" : "setenv.sh",
   "contentType" : "text/plain",

--- a/jwala-integration-test/src/test/resources/postman/test.json
+++ b/jwala-integration-test/src/test/resources/postman/test.json
@@ -1,7 +1,7 @@
 {
     "templateName":"CatalinaProperties.tpl",
     "contentType":"text/plain",
-    "deployPath":"${vars.'remote.paths.instances'}/${jvm.jvmName}/apache-tomcat-7.0.55/conf",
+    "deployPath":"${jvm.tomcatMedia.mediaDir}/${jvm.jvmName}/${jvm.tomcatMedia.rootDir}/conf",
     "deployFileName":"catalina.properties",
     "entity":{
         "type":"GROUPED_JVMS",

--- a/jwala-integration-test/src/test/resources/postman/tomcat-users.json
+++ b/jwala-integration-test/src/test/resources/postman/tomcat-users.json
@@ -1,5 +1,5 @@
 {
-  "deployPath" : "${vars.'remote.paths.instances'}/${jvm.jvmName}/apache-tomcat-7.0.55/conf",
+  "deployPath" : "${jvm.tomcatMedia.mediaDir}/${jvm.jvmName}/${jvm.tomcatMedia.rootDir}/conf",
   "templateName" : "tomcatUsers.tpl",
   "deployFileName" : "tomcat-users.xml",
   "contentType" : "application/xml",

--- a/jwala-integration-test/src/test/resources/postman/windows/httpdconf.tpl
+++ b/jwala-integration-test/src/test/resources/postman/windows/httpdconf.tpl
@@ -35,7 +35,7 @@
 # least PidFile.
 #
 #ServerRoot ./
-ServerRoot "${webServer.apacheHttpdMedia.remoteDir}/${webServer.apacheHttpdMedia.mediaDir}/"
+ServerRoot "${webServer.apacheHttpdMedia.remoteDir}/${webServer.apacheHttpdMedia.rootDir}/"
 
 #
 # Mutex: Allows you to set the mutex mechanism and mutex file directory

--- a/jwala-persistence/src/main/java/com/cerner/jwala/persistence/jpa/domain/JpaMedia.java
+++ b/jwala-persistence/src/main/java/com/cerner/jwala/persistence/jpa/domain/JpaMedia.java
@@ -53,7 +53,7 @@ public class JpaMedia extends AbstractEntity<JpaMedia> {
     @ValidPath
     private String remoteDir; // e.g. c:/ctp
 
-    private String mediaDir;  // e.g. tomcat-7.0
+    private String rootDir;  // e.g. tomcat-7.0
 
     public Long getId() {
         return id;
@@ -100,13 +100,13 @@ public class JpaMedia extends AbstractEntity<JpaMedia> {
     }
 
     @JsonSerialize(using = PathToStringSerializer.class)
-    public Path getMediaDir() {
-        return StringUtils.isEmpty(mediaDir) ? null : Paths.get(mediaDir);
+    public Path getRootDir() {
+        return StringUtils.isEmpty(rootDir) ? null : Paths.get(rootDir);
     }
 
     @JsonDeserialize(using = StringToPathDeserializer.class)
-    public void setMediaDir(final Path mediaDir) {
-        this.mediaDir = mediaDir.toString();
+    public void setRootDir(final Path rootDir) {
+        this.rootDir = rootDir.toString();
     }
 
     @Override
@@ -136,7 +136,7 @@ public class JpaMedia extends AbstractEntity<JpaMedia> {
                 ", type=" + type +
                 ", localPath='" + localPath + '\'' +
                 ", remoteDir='" + remoteDir + '\'' +
-                ", mediaDir='" + mediaDir + '\'' +
+                ", rootDir='" + rootDir + '\'' +
                 '}';
     }
 

--- a/jwala-persistence/src/main/java/com/cerner/jwala/persistence/jpa/domain/builder/JvmBuilder.java
+++ b/jwala-persistence/src/main/java/com/cerner/jwala/persistence/jpa/domain/builder/JvmBuilder.java
@@ -65,8 +65,8 @@ public class JvmBuilder {
             return "";
         }
 
-        if (jdkMedia.getRemoteDir() != null && jdkMedia.getMediaDir() != null){
-            return jdkMedia.getRemoteDir() + "/" + jdkMedia.getMediaDir();
+        if (jdkMedia.getRemoteDir() != null && jdkMedia.getRootDir() != null){
+            return jdkMedia.getRemoteDir() + "/" + jdkMedia.getRootDir();
         } else {
             return "";
         }

--- a/jwala-persistence/src/test/java/com/cerner/jwala/dao/impl/MediaDaoImplTest.java
+++ b/jwala-persistence/src/test/java/com/cerner/jwala/dao/impl/MediaDaoImplTest.java
@@ -44,7 +44,7 @@ public class MediaDaoImplTest {
         media.setType(MediaType.JDK);
         media.setLocalPath(Paths.get("c:/java/jdk.zip"));
         media.setRemoteDir(Paths.get("c:/ctp"));
-        media.setMediaDir(Paths.get("jdk-1.8"));
+        media.setRootDir(Paths.get("jdk-1.8"));
         mediaDao.create(media);
         final JpaMedia foundMedia = mediaDao.find("jdk 1.8");
         assertEquals(media, foundMedia);

--- a/jwala-persistence/src/test/java/com/cerner/jwala/persistence/jpa/MediaEntityToMediaDtoTest.java
+++ b/jwala-persistence/src/test/java/com/cerner/jwala/persistence/jpa/MediaEntityToMediaDtoTest.java
@@ -23,7 +23,7 @@ public class MediaEntityToMediaDtoTest {
         jpaMedia.setName("JDK Lite");
         jpaMedia.setType(MediaType.JDK);
         jpaMedia.setLocalPath(Paths.get("localPath"));
-        jpaMedia.setMediaDir(Paths.get("mediaDir"));
+        jpaMedia.setRootDir(Paths.get("mediaDir"));
         jpaMedia.setRemoteDir(Paths.get("remoteDir"));
         final Media media = new ModelMapper().map(jpaMedia, Media.class);
 
@@ -31,7 +31,7 @@ public class MediaEntityToMediaDtoTest {
         assertEquals("JDK Lite", media.getName());
         assertEquals(MediaType.JDK, media.getType());
         assertEquals("localPath", media.getLocalPath().toString());
-        assertEquals("mediaDir", media.getMediaDir().toString());
+        assertEquals("mediaDir", media.getRootDir().toString());
         assertEquals("remoteDir", media.getRemoteDir().toString());
     }
 

--- a/jwala-persistence/src/test/java/com/cerner/jwala/persistence/jpa/service/WebServerCrudServiceImplTest.java
+++ b/jwala-persistence/src/test/java/com/cerner/jwala/persistence/jpa/service/WebServerCrudServiceImplTest.java
@@ -188,7 +188,7 @@ public class WebServerCrudServiceImplTest {
         media.setType(MediaType.JDK);
         media.setLocalPath(new File("d:/not/a/real/path.zip").toPath());
         media.setRemoteDir(new File("d:/fake/remote/path").toPath());
-        media.setMediaDir(new File("test-media").toPath());
+        media.setRootDir(new File("test-media").toPath());
 
         final JpaMedia someJpaMedia = mediaDao.create(media);
         final JpaJvm jvm = jvmCrudService.createJvm(createJvmReq, mediaDao.create(media), someJpaMedia);

--- a/jwala-persistence/src/test/java/com/cerner/jwala/persistence/jpa/service/app/impl/ApplicationCrudServiceImplTest.java
+++ b/jwala-persistence/src/test/java/com/cerner/jwala/persistence/jpa/service/app/impl/ApplicationCrudServiceImplTest.java
@@ -163,7 +163,7 @@ public class ApplicationCrudServiceImplTest {
         media.setType(MediaType.JDK);
         media.setLocalPath(new File("d:/not/a/real/path.zip").toPath());
         media.setRemoteDir(new File("d:/fake/remote/path").toPath());
-        media.setMediaDir(new File("test-media").toPath());
+        media.setRootDir(new File("test-media").toPath());
         jpaMedia = mediaDao.create(media);
         expGroupId = Identifier.id(jpaGroup.getId());
     }

--- a/jwala-persistence/src/test/java/com/cerner/jwala/persistence/jpa/service/jvm/impl/JvmCrudServiceImplTest.java
+++ b/jwala-persistence/src/test/java/com/cerner/jwala/persistence/jpa/service/jvm/impl/JvmCrudServiceImplTest.java
@@ -71,7 +71,7 @@ public class JvmCrudServiceImplTest {
         media.setType(MediaType.JDK);
         media.setLocalPath(new File("d:/not/a/real/path.zip").toPath());
         media.setRemoteDir(new File("d:/fake/remote/path").toPath());
-        media.setMediaDir(new File("test-media").toPath());
+        media.setRootDir(new File("test-media").toPath());
         jpaMedia = mediaDao.create(media);
         CreateJvmRequest createJvmRequest = new CreateJvmRequest(testJvmName, "testHostName", 100, 101, 102, 103, 104,
                 new Path("./jwala.png"), "", null, null, null, null);

--- a/jwala-persistence/src/test/java/com/cerner/jwala/persistence/service/jvm/AbstractJvmPersistenceServiceTest.java
+++ b/jwala-persistence/src/test/java/com/cerner/jwala/persistence/service/jvm/AbstractJvmPersistenceServiceTest.java
@@ -52,7 +52,7 @@ public abstract class AbstractJvmPersistenceServiceTest {
         media.setType(MediaType.JDK);
         media.setLocalPath(new File("d:/not/a/real/path.zip").toPath());
         media.setRemoteDir(new File("d:/fake/remote/path").toPath());
-        media.setMediaDir(new File("test-media").toPath());
+        media.setRootDir(new File("test-media").toPath());
         mediaDao.create(media);
 
         media = new JpaMedia();
@@ -60,7 +60,7 @@ public abstract class AbstractJvmPersistenceServiceTest {
         media.setType(MediaType.TOMCAT);
         media.setLocalPath(new File("d:/not/a/real/path.zip").toPath());
         media.setRemoteDir(new File("d:/fake/remote/path").toPath());
-        media.setMediaDir(new File("test-media").toPath());
+        media.setRootDir(new File("test-media").toPath());
         mediaDao.create(media);
 
         jvmHelper = new CommonJvmPersistenceServiceBehavior(jvmPersistenceService);

--- a/jwala-services/src/main/java/com/cerner/jwala/control/jvm/command/JvmCommandFactory.java
+++ b/jwala-services/src/main/java/com/cerner/jwala/control/jvm/command/JvmCommandFactory.java
@@ -177,7 +177,7 @@ public class JvmCommandFactory {
         final String trimmedJvmName = StringUtils.deleteWhitespace(jvm.getJvmName());
 
         final String jvmRootDir = Paths.get(jvm.getTomcatMedia().getRemoteDir().toString() + '/' + trimmedJvmName + '/' +
-                jvm.getTomcatMedia().getMediaDir()).normalize().toString();
+                jvm.getTomcatMedia().getRootDir()).normalize().toString();
 
         final DateTimeFormatter formatter = DateTimeFormat.forPattern("yyyyMMdd.HHmmss");
         final String dumpFile = "heapDump." + trimmedJvmName + "." + formatter.print(DateTime.now());
@@ -198,7 +198,7 @@ public class JvmCommandFactory {
      */
     private ExecCommand getExecCommandForThreadDump(String scriptName, Jvm jvm) {
         final String jvmRootDir = Paths.get(jvm.getTomcatMedia().getRemoteDir().toString() + '/' +
-                StringUtils.deleteWhitespace(jvm.getJvmName()) + '/' + jvm.getTomcatMedia().getMediaDir())
+                StringUtils.deleteWhitespace(jvm.getJvmName()) + '/' + jvm.getTomcatMedia().getRootDir())
                 .normalize().toString();
         return new ExecCommand(getFullPathScript(jvm, scriptName), jvm.getJavaHome(), jvmRootDir, jvm.getJvmName());
     }
@@ -260,7 +260,7 @@ public class JvmCommandFactory {
 
         List<String> formatStrings = Arrays.asList(getFullPathScript(jvm, INSTALL_SERVICE_SCRIPT_NAME.getValue()),
                 jvm.getJvmName(), jvm.getTomcatMedia().getRemoteDir().normalize().toString(),
-                jvm.getTomcatMedia().getMediaDir().toString());
+                jvm.getTomcatMedia().getRootDir().toString());
         List<String> unformatStrings = Arrays.asList(quotedUsername, decryptedPassword);
 
         return new ExecCommand(formatStrings, unformatStrings);

--- a/jwala-services/src/main/java/com/cerner/jwala/control/webserver/command/WebServerCommandFactory.java
+++ b/jwala-services/src/main/java/com/cerner/jwala/control/webserver/command/WebServerCommandFactory.java
@@ -107,7 +107,7 @@ public class WebServerCommandFactory {
             final String installServiceWsScriptName = INSTALL_WS_SERVICE_SCRIPT_NAME.getValue();
             checkExistsAndCopy(webServer, installServiceWsScriptName);
 
-            final String apacheHttpdDir = webServer.getApacheHttpdMedia().getRemoteDir().toString() + "/" + webServer.getApacheHttpdMedia().getMediaDir().normalize().toString();
+            final String apacheHttpdDir = webServer.getApacheHttpdMedia().getRemoteDir().toString() + "/" + webServer.getApacheHttpdMedia().getRootDir().normalize().toString();
 
             return remoteCommandExecutorService.executeCommand(new RemoteExecCommand(getConnection(webServer),
                     getShellCommand(installServiceWsScriptName, webServer, getHttpdConfPath(webServer), apacheHttpdDir)));

--- a/jwala-services/src/main/java/com/cerner/jwala/service/binarydistribution/impl/BinaryDistributionServiceImpl.java
+++ b/jwala-services/src/main/java/com/cerner/jwala/service/binarydistribution/impl/BinaryDistributionServiceImpl.java
@@ -60,7 +60,7 @@ public class BinaryDistributionServiceImpl implements BinaryDistributionService 
 
         try {
             binaryDistributionLockManager.writeLock(hostName);
-            if (!checkIfMediaDirExists(media.getMediaDir().toString().split(","), hostName, installPath)) {
+            if (!checkIfMediaDirExists(media.getRootDir().toString().split(","), hostName, installPath)) {
                 historyFacadeService.write(hostName, Arrays.asList(groups), "Distribute " + media.getName(), EventType.SYSTEM_INFO,
                         getUserNameFromSecurityContext());
                 distributeBinary(hostName, media.getLocalPath().toString(), installPath, EXCLUDED_FILES);

--- a/jwala-services/src/main/java/com/cerner/jwala/service/jvm/impl/JvmServiceImpl.java
+++ b/jwala-services/src/main/java/com/cerner/jwala/service/jvm/impl/JvmServiceImpl.java
@@ -61,6 +61,7 @@ import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Paths;
 import java.text.MessageFormat;
 import java.util.*;
 
@@ -414,7 +415,7 @@ public class JvmServiceImpl implements JvmService {
             //
             final String jvmConfigJar = generateJvmConfigJar(jvm);
 
-            // copy the jar file
+            // copy the jar file to the staging area
             secureCopyJvmConfigJar(jvm, jvmConfigJar, user);
 
             // call script to backup and tar the current directory and
@@ -723,14 +724,15 @@ public class JvmServiceImpl implements JvmService {
             throw new InternalErrorException(FaultType.REMOTE_COMMAND_FAILURE, standardError.isEmpty() ? CommandOutputReturnCode.fromReturnCode(execData.getReturnCode().getReturnCode()).getDesc() : standardError);
         }
 
-        // make sure the start/stop scripts are executable
-        String instancesDir = ApplicationProperties.getRequired(PropertyKeys.REMOTE_PATHS_INSTANCES_DIR);
-        String tomcatDirName = jvm.getTomcatMedia().getMediaDir().toString();
+        final String targetAbsoluteDir =
+                Paths.get(jvm.getJdkMedia().getRemoteDir().toString() + '/' + jvm.getJvmName() + '/' +
+                        jvm.getTomcatMedia().getMediaDir().toString() + "/bin").normalize().toString();
 
-        final String targetAbsoluteDir = instancesDir + '/' + jvm.getJvmName() + '/' + tomcatDirName + "/bin";
         if (!jvmControlService.executeCheckFileExistsCommand(jvm, targetAbsoluteDir).getReturnCode().wasSuccessful()) {
             LOGGER.debug("JVM not generated yet.. ");
         }
+
+        // make sure the start/stop scripts are executable
         if (!jvmControlService.executeChangeFileModeCommand(jvm, "a+x", targetAbsoluteDir, "*.sh").getReturnCode().wasSuccessful()) {
             String message = "Failed to change the file permissions in " + targetAbsoluteDir + " for jvm " + jvm.getJvmName();
             LOGGER.error(message);

--- a/jwala-services/src/main/java/com/cerner/jwala/service/jvm/impl/JvmServiceImpl.java
+++ b/jwala-services/src/main/java/com/cerner/jwala/service/jvm/impl/JvmServiceImpl.java
@@ -726,7 +726,7 @@ public class JvmServiceImpl implements JvmService {
 
         final String targetAbsoluteDir =
                 Paths.get(jvm.getJdkMedia().getRemoteDir().toString() + '/' + jvm.getJvmName() + '/' +
-                        jvm.getTomcatMedia().getMediaDir().toString() + "/bin").normalize().toString();
+                        jvm.getTomcatMedia().getRootDir().toString() + "/bin").normalize().toString();
 
         if (!jvmControlService.executeCheckFileExistsCommand(jvm, targetAbsoluteDir).getReturnCode().wasSuccessful()) {
             LOGGER.debug("JVM not generated yet.. ");

--- a/jwala-services/src/main/java/com/cerner/jwala/service/jvm/impl/JvmServiceImpl.java
+++ b/jwala-services/src/main/java/com/cerner/jwala/service/jvm/impl/JvmServiceImpl.java
@@ -725,7 +725,7 @@ public class JvmServiceImpl implements JvmService {
         }
 
         final String targetAbsoluteDir =
-                Paths.get(jvm.getJdkMedia().getRemoteDir().toString() + '/' + jvm.getJvmName() + '/' +
+                Paths.get(jvm.getTomcatMedia().getRemoteDir().toString() + '/' + jvm.getJvmName() + '/' +
                         jvm.getTomcatMedia().getRootDir().toString() + "/bin").normalize().toString();
 
         if (!jvmControlService.executeCheckFileExistsCommand(jvm, targetAbsoluteDir).getReturnCode().wasSuccessful()) {

--- a/jwala-services/src/main/java/com/cerner/jwala/service/media/impl/MediaServiceImpl.java
+++ b/jwala-services/src/main/java/com/cerner/jwala/service/media/impl/MediaServiceImpl.java
@@ -92,7 +92,7 @@ public class MediaServiceImpl implements MediaService {
 
         final Set<String> zipRootDirSet = fileUtility.getZipRootDirs(dest);
         if (!zipRootDirSet.isEmpty()) {
-            media.setMediaDir(Paths.get(StringUtils.join(zipRootDirSet, ",")));
+            media.setRootDir(Paths.get(StringUtils.join(zipRootDirSet, ",")));
             media.setLocalPath(Paths.get(dest));
             return mediaDao.create(media);
         }

--- a/jwala-services/src/test/java/com/cerner/jwala/control/jvm/command/JvmCommandFactoryTest.java
+++ b/jwala-services/src/test/java/com/cerner/jwala/control/jvm/command/JvmCommandFactoryTest.java
@@ -28,6 +28,7 @@ import org.springframework.test.context.support.AnnotationConfigContextLoader;
 
 import java.io.File;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.*;
@@ -37,7 +38,6 @@ import static org.mockito.Mockito.*;
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(loader = AnnotationConfigContextLoader.class, classes = {JvmCommandFactoryTest.Config.class})
-
 public class JvmCommandFactoryTest {
 
     private static final RemoteCommandReturnInfo SUCCESS_REMOTE_COMMAND_INFO = new RemoteCommandReturnInfo(0, "standard out", "");
@@ -102,6 +102,7 @@ public class JvmCommandFactoryTest {
         Media mockTomcatMedia = mock(Media.class);
         Path mockPath = mock(Path.class);
         when(mockTomcatMedia.getMediaDir()).thenReturn(mockPath);
+        when(mockTomcatMedia.getRemoteDir()).thenReturn(Paths.get("d:/ctp/app/instance"));
         when(mockPath.toString()).thenReturn("test-tomcat-7");
         when(mockJvm.getTomcatMedia()).thenReturn(mockTomcatMedia);
 
@@ -127,6 +128,7 @@ public class JvmCommandFactoryTest {
         Media mockTomcatMedia = mock(Media.class);
         Path mockPath = mock(Path.class);
         when(mockTomcatMedia.getMediaDir()).thenReturn(mockPath);
+        when(mockTomcatMedia.getRemoteDir()).thenReturn(Paths.get("d:/ctp/app/instance"));
         when(mockPath.toString()).thenReturn("test-tomcat-7");
         when(mockJvm.getTomcatMedia()).thenReturn(mockTomcatMedia);
 
@@ -149,6 +151,10 @@ public class JvmCommandFactoryTest {
         when(mockJvm.getJvmName()).thenReturn("test-jvm-command-factory");
         when(mockJvm.getJavaHome()).thenReturn("c:/jdk/java-home");
 
+        final Media tomcatMedia = new Media();
+        tomcatMedia.setRemoteDir(Paths.get("d:/ctp/app/instance"));
+        when(mockJvm.getTomcatMedia()).thenReturn(tomcatMedia);
+
         when(Config.mockRemoteCommandExecutorService.executeCommand(any(RemoteExecCommand.class))).thenReturn(SUCCESS_REMOTE_COMMAND_INFO);
 
         when(Config.mockBinaryDistributionControlService.checkFileExists(anyString(), anyString())).thenReturn(new CommandOutput(new ExecReturnCode(0), "File exists", ""));
@@ -168,6 +174,7 @@ public class JvmCommandFactoryTest {
         Media mockTomcatMedia = mock(Media.class);
         Path mockPath = mock(Path.class);
         when(mockTomcatMedia.getMediaDir()).thenReturn(mockPath);
+        when(mockTomcatMedia.getRemoteDir()).thenReturn(Paths.get("d:/ctp/app/instance"));
         when(mockPath.toString()).thenReturn("test-tomcat-7");
 
         when(mockJvm.getTomcatMedia()).thenReturn(mockTomcatMedia);

--- a/jwala-services/src/test/java/com/cerner/jwala/control/jvm/command/JvmCommandFactoryTest.java
+++ b/jwala-services/src/test/java/com/cerner/jwala/control/jvm/command/JvmCommandFactoryTest.java
@@ -101,7 +101,7 @@ public class JvmCommandFactoryTest {
 
         Media mockTomcatMedia = mock(Media.class);
         Path mockPath = mock(Path.class);
-        when(mockTomcatMedia.getMediaDir()).thenReturn(mockPath);
+        when(mockTomcatMedia.getRootDir()).thenReturn(mockPath);
         when(mockTomcatMedia.getRemoteDir()).thenReturn(Paths.get("d:/ctp/app/instance"));
         when(mockPath.toString()).thenReturn("test-tomcat-7");
         when(mockJvm.getTomcatMedia()).thenReturn(mockTomcatMedia);
@@ -127,7 +127,7 @@ public class JvmCommandFactoryTest {
 
         Media mockTomcatMedia = mock(Media.class);
         Path mockPath = mock(Path.class);
-        when(mockTomcatMedia.getMediaDir()).thenReturn(mockPath);
+        when(mockTomcatMedia.getRootDir()).thenReturn(mockPath);
         when(mockTomcatMedia.getRemoteDir()).thenReturn(Paths.get("d:/ctp/app/instance"));
         when(mockPath.toString()).thenReturn("test-tomcat-7");
         when(mockJvm.getTomcatMedia()).thenReturn(mockTomcatMedia);
@@ -173,7 +173,7 @@ public class JvmCommandFactoryTest {
 
         Media mockTomcatMedia = mock(Media.class);
         Path mockPath = mock(Path.class);
-        when(mockTomcatMedia.getMediaDir()).thenReturn(mockPath);
+        when(mockTomcatMedia.getRootDir()).thenReturn(mockPath);
         when(mockTomcatMedia.getRemoteDir()).thenReturn(Paths.get("d:/ctp/app/instance"));
         when(mockPath.toString()).thenReturn("test-tomcat-7");
 

--- a/jwala-services/src/test/java/com/cerner/jwala/control/webserver/command/WebServerCommandFactoryTest.java
+++ b/jwala-services/src/test/java/com/cerner/jwala/control/webserver/command/WebServerCommandFactoryTest.java
@@ -135,7 +135,7 @@ public class WebServerCommandFactoryTest {
 
         final Media apacheHttpdMedia = new Media();
         apacheHttpdMedia.setRemoteDir(Paths.get("c:/ctp"));
-        apacheHttpdMedia.setMediaDir(Paths.get("Apache24"));
+        apacheHttpdMedia.setRootDir(Paths.get("Apache24"));
         apacheHttpdMedia.setType(MediaType.APACHE);
         when(mockWebServer.getApacheHttpdMedia()).thenReturn(apacheHttpdMedia);
 
@@ -199,7 +199,7 @@ public class WebServerCommandFactoryTest {
 
         final Media apacheHttpdMedia = new Media();
         apacheHttpdMedia.setRemoteDir(Paths.get("c:/ctp"));
-        apacheHttpdMedia.setMediaDir(Paths.get("Apache24"));
+        apacheHttpdMedia.setRootDir(Paths.get("Apache24"));
         apacheHttpdMedia.setType(MediaType.APACHE);
         when(mockWebServer.getApacheHttpdMedia()).thenReturn(apacheHttpdMedia);
 

--- a/jwala-services/src/test/java/com/cerner/jwala/service/binarydistribution/BinaryDistributionServiceImplTest.java
+++ b/jwala-services/src/test/java/com/cerner/jwala/service/binarydistribution/BinaryDistributionServiceImplTest.java
@@ -226,7 +226,7 @@ public class BinaryDistributionServiceImplTest {
         final Media mockJdkMedia = mock(Media.class);
         when(mockJdkMedia.getRemoteDir()).thenReturn(Paths.get("anywhere"));
         when(mockJdkMedia.getLocalPath()).thenReturn(Paths.get("anyLocalPath"));
-        when(mockJdkMedia.getMediaDir()).thenReturn(Paths.get("anywhere"));
+        when(mockJdkMedia.getRootDir()).thenReturn(Paths.get("anywhere"));
         when(mockJdkMedia.getType()).thenReturn(MediaType.JDK);
         when(Config.mockBinaryDistributionControlService.checkFileExists(anyString(), anyString())).thenReturn(unsuccessfulCommandOutout);
         when(Config.mockBinaryDistributionControlService.createDirectory(eq(hostname), anyString())).thenReturn(successfulCommandOutput);
@@ -246,7 +246,7 @@ public class BinaryDistributionServiceImplTest {
         final CommandOutput successfulCommandOutput = new CommandOutput(new ExecReturnCode(0), "SUCCESS", "");
         final Media mockJdkMedia = mock(Media.class);
         when(mockJdkMedia.getRemoteDir()).thenReturn(Paths.get("anywhere"));
-        when(mockJdkMedia.getMediaDir()).thenReturn(Paths.get("anywhere"));
+        when(mockJdkMedia.getRootDir()).thenReturn(Paths.get("anywhere"));
         when(mockJdkMedia.getType()).thenReturn(MediaType.JDK);
         when(Config.mockBinaryDistributionControlService.checkFileExists(anyString(), anyString())).thenReturn(successfulCommandOutput);
 
@@ -270,7 +270,7 @@ public class BinaryDistributionServiceImplTest {
         Path binaryPath = Paths.get(remoteDir.normalize().toString() + File.separator + apacheZipName);
 
         media.setRemoteDir(remoteDir);
-        media.setMediaDir(mediaDir);
+        media.setRootDir(mediaDir);
         media.setLocalPath(localPath);
         media.setType(MediaType.APACHE);
         final Group[] groupArray = new Group[1];

--- a/jwala-services/src/test/resources/managerXml/vars.properties
+++ b/jwala-services/src/test/resources/managerXml/vars.properties
@@ -5,7 +5,6 @@ jwala.default.role.mapping.properties=RoleMappingTemplate.tpl
 paths.generated.resource.dir=./build/generated
 remote.jwala.webapps.dir=./src/test/resources/webapps
 net.stop.sleep.time.seconds=20
-remote.paths.instances=d:/jwala/app/instances
 test.jwala.property=found it!
 
 # binary distribution

--- a/jwala-services/src/test/resources/vars-applicationContextListener.properties
+++ b/jwala-services/src/test/resources/vars-applicationContextListener.properties
@@ -5,7 +5,6 @@ jwala.default.role.mapping.properties=RoleMappingTemplate.tpl
 paths.generated.resource.dir=./build/generated
 remote.jwala.webapps.dir=./src/test/resources/webapps
 net.stop.sleep.time.seconds=20
-remote.paths.instances=d:/jwala/app/instances
 test.jwala.property=found it!
 
 # binary distribution

--- a/jwala-services/src/test/resources/vars-applicationContextListenerBypass.properties
+++ b/jwala-services/src/test/resources/vars-applicationContextListenerBypass.properties
@@ -5,7 +5,6 @@ jwala.default.role.mapping.properties=RoleMappingTemplate.tpl
 paths.generated.resource.dir=./build/generated
 remote.jwala.webapps.dir=./src/test/resources/webapps
 net.stop.sleep.time.seconds=20
-remote.paths.instances=d:/jwala/app/instances
 test.jwala.property=found it!
 
 # binary distribution

--- a/jwala-services/src/test/resources/vars.properties
+++ b/jwala-services/src/test/resources/vars.properties
@@ -5,7 +5,6 @@ jwala.default.role.mapping.properties=RoleMappingTemplate.tpl
 paths.generated.resource.dir=./build/generated
 remote.jwala.webapps.dir=./src/test/resources/webapps
 net.stop.sleep.time.seconds=20
-remote.paths.instances=d:/jwala/app/instances
 test.jwala.property=found it!
 
 # binary distribution

--- a/jwala-tomcat/src/main/resources/data/properties/vars.properties
+++ b/jwala-tomcat/src/main/resources/data/properties/vars.properties
@@ -6,8 +6,6 @@ remote.paths.apache.httpd=#REQUIRED#
 jwala.apache.httpd.zip.name=apache-httpd-2.4.20.zip
 remote.paths.httpd.root.dir.name=apache-httpd-2.4.20
 
-remote.paths.instances=#REQUIRED#
-
 remote.commands.user-scripts=~/.jwala
 
 ssh.userName=#REQUIRED#

--- a/jwala-tomcat/src/main/resources/data/templates/httpd.conf.tpl
+++ b/jwala-tomcat/src/main/resources/data/templates/httpd.conf.tpl
@@ -34,7 +34,7 @@
 # same ServerRoot for multiple httpd daemons, you will need to change at
 # least PidFile.
 #
-ServerRoot "${webServer.apacheHttpdMedia.remoteDir}/${webServer.apacheHttpdMedia.mediaDir}"
+ServerRoot "${webServer.apacheHttpdMedia.remoteDir}/${webServer.apacheHttpdMedia.rootDir}"
 
 #
 # Mutex: Allows you to set the mutex mechanism and mutex file directory
@@ -240,8 +240,8 @@ ServerAdmin admin@example.com
 # documents. By default, all requests are taken from this directory, but
 # symbolic links and aliases may be used to point to other locations.
 #
-DocumentRoot "${webServer.apacheHttpdMedia.remoteDir}/${webServer.apacheHttpdMedia.mediaDir}/htdocs"
-<Directory "${webServer.apacheHttpdMedia.remoteDir}/${webServer.apacheHttpdMedia.mediaDir}/htdocs">
+DocumentRoot "${webServer.apacheHttpdMedia.remoteDir}/${webServer.apacheHttpdMedia.rootDir}/htdocs"
+<Directory "${webServer.apacheHttpdMedia.remoteDir}/${webServer.apacheHttpdMedia.rootDir}/htdocs">
     #
     # Possible values for the Options directive are "None", "All",
     # or any combination of:
@@ -357,7 +357,7 @@ LogLevel warn
     # client.  The same rules about trailing "/" apply to ScriptAlias
     # directives as to Alias.
     #
-    ScriptAlias /cgi-bin/ "${webServer.apacheHttpdMedia.remoteDir}/${webServer.apacheHttpdMedia.mediaDir}/cgi-bin/"
+    ScriptAlias /cgi-bin/ "${webServer.apacheHttpdMedia.remoteDir}/${webServer.apacheHttpdMedia.rootDir}/cgi-bin/"
 
 </IfModule>
 
@@ -370,10 +370,10 @@ LogLevel warn
 </IfModule>
 
 #
-# "${webServer.apacheHttpdMedia.remoteDir}/${webServer.apacheHttpdMedia.mediaDir}/cgi-bin" should be changed to whatever your ScriptAliased
+# "${webServer.apacheHttpdMedia.remoteDir}/${webServer.apacheHttpdMedia.rootDir}/cgi-bin" should be changed to whatever your ScriptAliased
 # CGI directory exists, if you have that configured.
 #
-<Directory "${webServer.apacheHttpdMedia.remoteDir}/${webServer.apacheHttpdMedia.mediaDir}/cgi-bin">
+<Directory "${webServer.apacheHttpdMedia.remoteDir}/${webServer.apacheHttpdMedia.rootDir}/cgi-bin">
     AllowOverride None
     Options None
     Require all granted

--- a/jwala-tomcat/src/main/resources/data/templates/install-service-http.bat.tpl
+++ b/jwala-tomcat/src/main/resources/data/templates/install-service-http.bat.tpl
@@ -1,5 +1,5 @@
 @ECHO OFF
 
-${webServer.apacheHttpdMedia.remoteDir}\\${webServer.apacheHttpdMedia.mediaDir}\bin\httpd -k install -n ${webServer.name} -f %1
+${webServer.apacheHttpdMedia.remoteDir}\\${webServer.apacheHttpdMedia.rootDir}\bin\httpd -k install -n ${webServer.name} -f %1
 CMD /C SC config ${webServer.name} DisplayName= "Apache ${webServer.name}"
 POPD

--- a/jwala-tomcat/src/main/resources/data/templates/install-service-jvm.bat.tpl
+++ b/jwala-tomcat/src/main/resources/data/templates/install-service-jvm.bat.tpl
@@ -4,7 +4,7 @@ set svc_username=%1
 set svc_password=%2
 
 SET JAVA_HOME=${jvm.javaHome}
-SET CATALINA_HOME=${vars['remote.paths.instances']}\\${jvm.jvmName}\\${jvm.tomcatMedia.rootDir}
+SET CATALINA_HOME=${jvm.tomcatMedia.remoteDir]}\\${jvm.jvmName}\\${jvm.tomcatMedia.rootDir}
 SET TOMCAT_BIN_DIR=%CATALINA_HOME%\bin
 
 if exist %TOMCAT_BIN_DIR%\setenv.bat CALL %TOMCAT_BIN_DIR%\setenv.bat

--- a/jwala-tomcat/src/main/resources/data/templates/install-service-jvm.bat.tpl
+++ b/jwala-tomcat/src/main/resources/data/templates/install-service-jvm.bat.tpl
@@ -4,7 +4,7 @@ set svc_username=%1
 set svc_password=%2
 
 SET JAVA_HOME=${jvm.javaHome}
-SET CATALINA_HOME=${vars['remote.paths.instances']}\\${jvm.jvmName}\\${jvm.tomcatMedia.mediaDir}
+SET CATALINA_HOME=${vars['remote.paths.instances']}\\${jvm.jvmName}\\${jvm.tomcatMedia.rootDir}
 SET TOMCAT_BIN_DIR=%CATALINA_HOME%\bin
 
 if exist %TOMCAT_BIN_DIR%\setenv.bat CALL %TOMCAT_BIN_DIR%\setenv.bat
@@ -26,7 +26,7 @@ IF "%JAVA_SERVICE_OPTS%" NEQ "" SET SERVICE_OPTS=++JvmOptions %JAVA_SERVICE_OPTS
 IF "%START_PATH%" NEQ "" SET SERVICE_OPTS=%SERVICE_OPTS% --StartPath %START_PATH%
 
 ECHO Update Java Options
-CMD /C  %TOMCAT_BIN_DIR%\\tomcat${jvm.tomcatMedia.mediaDir.toString().minus('apache-tomcat-').tokenize('.')[0]}.exe //US//${jvm.jvmName} --JavaHome ${jvm.javaHome} %SERVICE_OPTS% --StdOutput "" --StdError ""
+CMD /C  %TOMCAT_BIN_DIR%\\tomcat${jvm.tomcatMedia.rootDir.toString().minus('apache-tomcat-').tokenize('.')[0]}.exe //US//${jvm.jvmName} --JavaHome ${jvm.javaHome} %SERVICE_OPTS% --StdOutput "" --StdError ""
 
 ECHO Change the service to automatically start
 SC CONFIG ${jvm.jvmName} start= auto

--- a/jwala-webapp/src/main/webapp/resources/js/react/MediaConfig.js
+++ b/jwala-webapp/src/main/webapp/resources/js/react/MediaConfig.js
@@ -17,7 +17,7 @@ var MediaConfig = React.createClass({
                                                 {title: "Name", key: "name", renderCallback: this.mediaNameRenderCallback},
                                                 {title: "Type", key: "type.displayName"},
                                                 {title: "Remote Target Directory", key: "remoteDir"},
-                                                {title: "Media Directory Name", key: "mediaDir"}]}
+                                                {title: "Media Directory Name", key: "rootDir"}]}
                                selectItemCallback={this.selectItemCallback}
                                deselectAllRowsCallback={this.deselectAllRowsCallback}/>
 
@@ -123,7 +123,7 @@ var MediaConfig = React.createClass({
                                                 formData["localPath"] = response.applicationResponseContent.localPath;
                                                 formData["type"] = response.applicationResponseContent.type;
                                                 formData["remoteDir"] = response.applicationResponseContent.remoteDir;
-                                                formData["mediaDir"] = response.applicationResponseContent.mediaDir;
+                                                formData["rootDir"] = response.applicationResponseContent.mediaDir;
                                                 self.refs.modalEditMediaDlg.show("Edit Media", <MediaConfigForm formData={formData}/>);
                                            })).caught(
                                                 function(response){$.errorAlert(response)
@@ -140,13 +140,13 @@ var MediaConfigForm = React.createClass({
         var type = this.props.formData && this.props.formData.type ? this.props.formData.type.name : null;
         var localPath = this.props.formData && this.props.formData.localPath ? this.props.formData.localPath : null;
         var remoteDir = this.props.formData && this.props.formData.remoteDir ? this.props.formData.remoteDir : null;
-        var mediaDir = this.props.formData && this.props.formData.mediaDir ? this.props.formData.mediaDir : null;
-        return {name: name, type: type, mediaArchiveFilename: "", mediaArchiveFile: null, remoteDir: remoteDir, mediaDir: mediaDir, showUploadBusy: false};
+        var rootDir = this.props.formData && this.props.formData.rootDir ? this.props.formData.rootDir : null;
+        return {name: name, type: type, mediaArchiveFilename: "", mediaArchiveFile: null, remoteDir: remoteDir, rootDir: rootDir, showUploadBusy: false};
     },
     render: function() {
         var idTextHidden = null;
         var localPathTextHidden = null;
-        var mediaDirTextHidden = null;
+        var rootDirTextHidden = null;
         var mediaArchiveFileInput = null;
         var uploadBusyImg = this.state.showUploadBusy ? <span>Uploading {this.state.mediaArchiveFile.name} ...
                     <img className="uploadMediaBusyIcon" src="public-resources/img/busy-circular.gif"/></span>: null;
@@ -154,7 +154,7 @@ var MediaConfigForm = React.createClass({
         if (this.props.formData && this.props.formData.id) {
             idTextHidden = <input type="hidden" name="id" value={this.props.formData.id}/>;
             localPathTextHidden = <input type="hidden" name="localPath" value={this.props.formData.localPath}/>;
-            mediaDirTextHidden = <input type="hidden" name="mediaDir" value={this.props.formData.mediaDir}/>;
+            rootDirTextHidden = <input type="hidden" name="mediaDir" value={this.props.formData.mediaDir}/>;
         } else {
             mediaArchiveFileInput = <div>
                                         <label>Media Archive File</label>
@@ -168,7 +168,7 @@ var MediaConfigForm = React.createClass({
                    <form ref="form" enctype="multipart/form-data">
                        {idTextHidden}
                        {localPathTextHidden}
-                       {mediaDirTextHidden}
+                       {rootDirTextHidden}
                        <label>Name</label>
                        <label htmlFor="name" className="error"/>
                        <input name="name" type="text" valueLink={this.linkState("name")} maxLength="255" required autoFocus/>

--- a/jwala-webapp/src/test/resources/vars.properties
+++ b/jwala-webapp/src/test/resources/vars.properties
@@ -1,5 +1,4 @@
 paths.resource-templates=./src/test/resources
-remote.paths.instances=.
 commands.scripts-path=./src/test/resources
 paths.generated.resource.dir=./src/test/resources/jvm-resources_test
 

--- a/jwala-webservices/src/test/java/com/cerner/jwala/ws/rest/v1/service/media/impl/MediaServiceRestImplTest.java
+++ b/jwala-webservices/src/test/java/com/cerner/jwala/ws/rest/v1/service/media/impl/MediaServiceRestImplTest.java
@@ -52,7 +52,7 @@ public class MediaServiceRestImplTest {
         ms.setType(MediaType.JDK);
         ms.setLocalPath(Paths.get("c:/java/jdk.zip"));
         ms.setRemoteDir(Paths.get("c:/ctp"));
-        ms.setMediaDir(Paths.get("jdk-1.8"));
+        ms.setRootDir(Paths.get("jdk-1.8"));
         final List<JpaMedia> result = new ArrayList<>();
         result.add(ms);
 
@@ -72,7 +72,7 @@ public class MediaServiceRestImplTest {
         media.setType(MediaType.JDK);
         media.setLocalPath(Paths.get("c:/java/jdk.zip"));
         media.setRemoteDir(Paths.get("c:/ctp"));
-        media.setMediaDir(Paths.get("jdk-1.8"));
+        media.setRootDir(Paths.get("jdk-1.8"));
 
         reset(Config.mediaService);
     }

--- a/jwala-webservices/src/test/resources/vars.properties
+++ b/jwala-webservices/src/test/resources/vars.properties
@@ -1,5 +1,4 @@
 paths.resource-templates=./src/test/resources
-remote.paths.instances=.
 commands.scripts-path=./src/test/resources
 paths.generated.resource.dir=./build
 


### PR DESCRIPTION
User should be able to install JVM anywhere by specifying the location in the remote dir of media