### PR TITLE
Media object should implement the hashCode and equals operators, so t…

### DIFF
--- a/jwala-common/src/main/java/com/cerner/jwala/common/domain/model/media/Media.java
+++ b/jwala-common/src/main/java/com/cerner/jwala/common/domain/model/media/Media.java
@@ -1,11 +1,14 @@
 package com.cerner.jwala.common.domain.model.media;
 
-import com.cerner.jwala.common.domain.model.PathToStringSerializer;
-import com.cerner.jwala.common.domain.model.StringToPathDeserializer;
+import java.nio.file.Path;
+
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.codehaus.jackson.map.annotate.JsonDeserialize;
 import org.codehaus.jackson.map.annotate.JsonSerialize;
 
-import java.nio.file.Path;
+import com.cerner.jwala.common.domain.model.PathToStringSerializer;
+import com.cerner.jwala.common.domain.model.StringToPathDeserializer;
 
 /**
  * Created by Rahul Sayini on 12/2/2016
@@ -17,19 +20,19 @@ public class Media {
     private MediaType type;
     private Path localPath;
     private Path remoteDir;
-    private Path mediaDir;
+    private Path rootDir;
 
     public Media() {
     }
 
     public Media(final Long id, final String name, final MediaType type, final Path path, final Path remoteDir,
-                 final Path mediaDir) {
+                 final Path rootDir) {
         this.id = id;
         this.name = name;
         this.type = type;
         this.localPath = path;
         this.remoteDir = remoteDir;
-        this.mediaDir = mediaDir;
+        this.rootDir = rootDir;
     }
 
     public Long getId() {
@@ -77,13 +80,44 @@ public class Media {
     }
 
     @JsonSerialize(using = PathToStringSerializer.class)
-    public Path getMediaDir() {
-        return mediaDir;
+    public Path getRootDir() {
+        return rootDir;
     }
 
     @JsonDeserialize(using = StringToPathDeserializer.class)
-    public void setMediaDir(Path mediaDir) {
-        this.mediaDir = mediaDir;
+    public void setRootDir(Path rootDir) {
+        this.rootDir = rootDir;
+    }
+
+    
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder(17, 37)
+                .append(id)
+                .append(name)
+                .append(type)
+                .append(localPath)
+                .append(remoteDir)
+                .append(rootDir)
+                .toHashCode();    
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+
+        if (o == null || getClass() != o.getClass()) return false;
+
+        Media media = (Media) o;
+
+        return new EqualsBuilder()
+                .append(id, media.id)
+                .append(name, media.name)
+                .append(type, media.type)
+                .append(localPath, media.localPath)
+                .append(remoteDir, media.remoteDir)
+                .append(rootDir, media.rootDir)
+                .isEquals();
     }
 
 }


### PR DESCRIPTION
…hat Jvm object comparison will properly detect same/different tomcat and jdk media.

SOARCOM-2889 reports that we send multiple stop/start requests when we do Start All Groups and Stop All Groups. The Set<Jvm> adds the JVMs multiple times because the hashCode and Equals operators of the Jvm class do not take the Media objects into account.

Before you contribute, please review these guidelines to help ensure a smooth process for everyone.

Thanks.

* Read [how to properly contribute to open source projects on Github][1].
* Fork the project.
* Use a feature branch.
* Write [good commit messages][2].
* Use the same coding conventions as the rest of the project.
* Commit locally and push to your fork until you are happy with your contribution.
* Make sure to add tests and verify all the tests are passing when merging upstream.
* Add an entry to the [Changelog][3] accordingly.
* Please add your name to the [CONTRIBUTORS.md][7] file. Adding your name to the [CONTRIBUTORS.md][7] file signifies agreement to all rights and reservations provided by the [License][4].
* [Squash related commits together][5].
* Open a [pull request][6].
* The pull request will be reviewed by the community and merged by the project committers.

[1]: http://gun.io/blog/how-to-github-fork-branch-and-pull-request
[2]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[3]: ./CHANGELOG.md
[4]: ./LICENSE
[5]: http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html
[6]: https://help.github.com/articles/using-pull-requests
[7]: ./CONTRIBUTORS.md
