### PR TITLE
Fix bug wherein constraint violation occurs when uploading a WAR file

### DIFF
--- a/jwala-persistence/src/main/java/com/cerner/jwala/persistence/jpa/domain/resource/config/template/JpaGroupAppConfigTemplate.java
+++ b/jwala-persistence/src/main/java/com/cerner/jwala/persistence/jpa/domain/resource/config/template/JpaGroupAppConfigTemplate.java
@@ -9,7 +9,7 @@ import javax.persistence.*;
  * POJO that describes a db table that holds data about a group of application related resource configuration templates.
  */
 @Entity
-@Table(name = "GRP_APP_CONFIG_TEMPLATE", uniqueConstraints = {@UniqueConstraint(columnNames = {"GRP_ID", "TEMPLATE_NAME"})})
+@Table(name = "GRP_APP_CONFIG_TEMPLATE", uniqueConstraints = {@UniqueConstraint(columnNames = {"GRP_ID", "APP_ID", "TEMPLATE_NAME"})})
 @NamedQueries({
         @NamedQuery(name = JpaGroupAppConfigTemplate.GET_GROUP_APP_TEMPLATE_RESOURCE_NAMES,
                 query = "SELECT t.templateName FROM JpaGroupAppConfigTemplate t WHERE t.grp.name = :grpName"),


### PR DESCRIPTION
The group application table should define 3 columns as the unique constraints which are group id, app id and template name

NOTE: It's to my understanding that CREATE.SQL is defined through the JPAs so we are good on that. The problem is that we need to update the upgrade scenario as well to contain the 3 columns as the unique key. I will update CHEF to reflect the change here.