### PR TITLE
Fix hashtag not accepted for resource name

### DIFF
--- a/jwala-integration-test/build.gradle
+++ b/jwala-integration-test/build.gradle
@@ -5,6 +5,9 @@ repositories {
 }
 
 dependencies {
+    testCompile group: "info.cukes", name: "cucumber-java", version: "1.1.8"
+    testCompile group: "info.cukes", name: "cucumber-junit", version: "1.1.8"
+
     testCompile group: 'junit', name: 'junit', version: '4.11'
     testCompile group: 'org.seleniumhq.selenium', name: 'selenium-java', version: '3.0.1'
     testCompile group: 'org.seleniumhq.selenium', name: 'selenium-firefox-driver', version: '3.0.1'

--- a/jwala-integration-test/src/test/java/com/cerner/jwala/ui/selenium/JwalaTestSuite.java
+++ b/jwala-integration-test/src/test/java/com/cerner/jwala/ui/selenium/JwalaTestSuite.java
@@ -46,7 +46,7 @@ import java.util.concurrent.TimeUnit;
  */
 @RunWith(Suite.class)
 @Suite.SuiteClasses({PreFlightTest.class, LoginTest.class, GroupCreateTest.class, JvmCreateTest.class, WebServerCreateTest.class,
-        AppCreateTest.class, AppSearchTest.class, ResourceTopologyTest.class, UploadResourceTest.class, AddExternalProperty.class,
+        AppCreateTest.class, AppSearchTest.class, ResourceTopologyTest.class, ResourceTest.class, AddExternalProperty.class,
         ModifyExternalPropertyResource.class, DeleteExternalProperty.class, ResourceDeployTest.class, HistoryTablePopupTest.class,
         AppDeleteTest.class, JvmOperationsPageDeleteTest.class, WebServerOperationsPageDelete.class, WebServerCreateTest.class,
         WebServerDeleteTest.class, JvmCreateTest.class, JvmDeleteTest.class, GroupDeleteTest.class, BalancerManagerTest.class,

--- a/jwala-integration-test/src/test/java/com/cerner/jwala/ui/selenium/testsuite/configuration/resources/ResourceTest.java
+++ b/jwala-integration-test/src/test/java/com/cerner/jwala/ui/selenium/testsuite/configuration/resources/ResourceTest.java
@@ -1,0 +1,11 @@
+package com.cerner.jwala.ui.selenium.testsuite.configuration.resources;
+
+import cucumber.api.junit.Cucumber;
+import org.junit.runner.RunWith;
+
+/**
+ * Created by Jedd Cuison on 6/13/2017
+ */
+@RunWith(Cucumber.class)
+public class ResourceTest {
+}

--- a/jwala-integration-test/src/test/java/com/cerner/jwala/ui/selenium/testsuite/configuration/resources/steps/CreateResource.java
+++ b/jwala-integration-test/src/test/java/com/cerner/jwala/ui/selenium/testsuite/configuration/resources/steps/CreateResource.java
@@ -1,24 +1,24 @@
-package com.cerner.jwala.ui.selenium.testsuite.configuration.resources;
+package com.cerner.jwala.ui.selenium.testsuite.configuration.resources.steps;
 
 import com.cerner.jwala.ui.selenium.testsuite.JwalaTest;
-import org.junit.Test;
+import cucumber.api.java.en.Given;
+import cucumber.api.java.en.Then;
+import cucumber.api.java.en.When;
 import org.openqa.selenium.By;
 import org.openqa.selenium.Keys;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.support.ui.WebDriverWait;
 
 /**
- * Replaced by {@link ResourceTest}
- *
- * Created by Jedd Cuison on 3/1/2017
+ * Created by Jedd Cuison on 6/13/2017
  */
-@Deprecated
-public class UploadResourceTest extends JwalaTest {
+public class CreateResource extends JwalaTest {
 
     private static final String GROUP_NAME_2 = "zGroup2-" + CURRENT_TIME_MILLIS;
+    private static final String RESOURCE_NAME_WITH_HASHTAG = "jwala-logo#2";
 
-    @Test
-    public void testUploadResource() {
+    @Given("^Hashtag in the resource name$")
+    public void hashTagInTheResourceName() {
         clickTab("Configuration");
         clickTab("Resources");
         clickTreeItemExpandCollapseIcon(GROUP_NAME_2);
@@ -26,15 +26,22 @@ public class UploadResourceTest extends JwalaTest {
         new WebDriverWait(driver, 5).until(ExpectedConditions.numberOfElementsToBe(
                 By.xpath("//li[span[text()='" + GROUP_NAME_2 + "']]//span[text()='JVMs' and contains(@class, 'ui-state-active')]"), 1));
         driver.findElement(By.xpath("//li[contains(@class, 'button')]/span[@title='create']")).click();
-        driver.switchTo().activeElement().sendKeys("jwala-logo");
+        driver.switchTo().activeElement().sendKeys(RESOURCE_NAME_WITH_HASHTAG);
         driver.switchTo().activeElement().sendKeys(Keys.TAB);
         driver.switchTo().activeElement().sendKeys("/jwala");
         driver.switchTo().activeElement().sendKeys(Keys.TAB);
         driver.switchTo().activeElement()
                 .sendKeys(this.getClass().getClassLoader().getResource("selenium/jwala-logo.png").getPath().replaceFirst("/", ""));
-        driver.findElement(By.xpath("//button[span[text()='Ok']]")).click();
+    }
 
-        testForBusyIcon(3, 10);
+    @When("^Resource is created$")
+    public void resourceCreated() {
+        driver.findElement(By.xpath("//button[span[text()='Ok']]")).click();
+    }
+
+    @Then("^Resource creation is successful$")
+    public void resourceCreatedSuccessfully() {
+        waitUntilElementIsVisible(By.xpath("//span[text()='" + RESOURCE_NAME_WITH_HASHTAG +  "']"));
     }
 
 }

--- a/jwala-integration-test/src/test/resources/com/cerner/jwala/ui/selenium/testsuite/configuration/resources/addResource.feature
+++ b/jwala-integration-test/src/test/resources/com/cerner/jwala/ui/selenium/testsuite/configuration/resources/addResource.feature
@@ -1,0 +1,7 @@
+Feature: CreateResource
+
+Scenario: Create a resource file with hashtag
+
+Given Hashtag in the resource name
+When Resource is created
+Then Resource creation is successful

--- a/jwala-webapp/src/main/webapp/resources/js/jwala/v1/service/resourceService.js
+++ b/jwala-webapp/src/main/webapp/resources/js/jwala/v1/service/resourceService.js
@@ -7,7 +7,7 @@ var resourceService = {
             return serviceFoundation.promisedPost("v1.0/resources/template/", "json", formData, null, true);
         }
         var matrixParam = this.createMatrixParam(groupName, webServerName, jvmName, webAppName);
-        return serviceFoundation.promisedPost("v1.0/resources/" + deployFilename + matrixParam, "json", formData, null, true, true);
+        return serviceFoundation.promisedPost("v1.0/resources/" + encodeURIComponent(deployFilename) + matrixParam, "json", formData, null, true, true);
     },
     deleteAllResource: function(resourceName) {
         return serviceFoundation.del("v1.0/resources/template/" + resourceName);


### PR DESCRIPTION
This fixes a bug wherein a resource with hashtag(s) in its names is not created. In addition a selenium test was written to validate this scenario. The test features an initial implementation of Cucumber.