### PR TITLE
JVM fails to install as Windows service with ampersand in password

### DIFF
--- a/jwala-services/src/main/java/com/cerner/jwala/control/jvm/command/JvmCommandFactory.java
+++ b/jwala-services/src/main/java/com/cerner/jwala/control/jvm/command/JvmCommandFactory.java
@@ -250,20 +250,26 @@ public class JvmCommandFactory {
             encryptedPassword = null;
         }
 
-        final String quotedUsername;
-        if (userName != null && userName.length() > 0) {
-            quotedUsername = "\"" + userName + "\"";
-        } else {
-            quotedUsername = "";
-        }
+        final String quotedUsername = addQuotes(userName);
         final String decryptedPassword = encryptedPassword != null && encryptedPassword.length() > 0 ? new DecryptPassword().decrypt(encryptedPassword) : "";
+        final String quotedPassword = addQuotes(decryptedPassword);
 
         List<String> formatStrings = Arrays.asList(getFullPathScript(jvm, INSTALL_SERVICE_SCRIPT_NAME.getValue()),
                 jvm.getJvmName(), jvm.getTomcatMedia().getRemoteDir().normalize().toString(),
                 jvm.getTomcatMedia().getRootDir().toString());
-        List<String> unformatStrings = Arrays.asList(quotedUsername, decryptedPassword);
+        List<String> unformatStrings = Arrays.asList(quotedUsername, quotedPassword);
 
         return new ExecCommand(formatStrings, unformatStrings);
+    }
+
+    private String addQuotes(String value) {
+        final String quotedValue;
+        if (value != null && value.length() > 0) {
+            quotedValue = "\"" + value + "\"";
+        } else {
+            quotedValue = "";
+        }
+        return quotedValue;
     }
 
     private ExecCommand getExecCommandForDeleteService(Jvm jvm) {

--- a/jwala-tomcat/src/main/resources/data/scripts/install-service.sh
+++ b/jwala-tomcat/src/main/resources/data/scripts/install-service.sh
@@ -25,7 +25,7 @@ if $cygwin; then
     exit $JWALA_EXIT_CODE_FAILED
   fi
 
-  $2/$1/$3/bin/install-service.bat "$4" "$5"
+  $2/$1/$3/bin/install-service.bat "$4" "${5//&/^&}"
   export EXIT_CODE=$?
   if [ "$EXIT_CODE" -ne "0" ]; then
     /usr/bin/echo Failed to install service $1

--- a/jwala-tomcat/src/main/resources/data/templates/install-service-jvm.bat.tpl
+++ b/jwala-tomcat/src/main/resources/data/templates/install-service-jvm.bat.tpl
@@ -1,8 +1,5 @@
 @ECHO ON
 
-set svc_username=%1
-set svc_password=%2
-
 SET JAVA_HOME=${jvm.javaHome}
 SET CATALINA_HOME=${jvm.tomcatMedia.remoteDir}\\${jvm.jvmName}\\${jvm.tomcatMedia.rootDir}
 SET TOMCAT_BIN_DIR=%CATALINA_HOME%\bin
@@ -37,12 +34,12 @@ IF "%ERRORLEVEL%" NEQ "0" (
     EXIT %ERRORLEVEL%"
 )
 
-if %svc_username%=="" goto :no_user
+if %1=="" goto :no_user
 
-if %svc_password%=="" (
-	SC CONFIG ${jvm.jvmName} obj= "%svc_username%"
+if "%2"=="""" (
+	SC CONFIG ${jvm.jvmName} obj= "%1"
 ) else (
-	SC CONFIG ${jvm.jvmName} obj= "%svc_username%" password= "%svc_password%"
+	SC CONFIG ${jvm.jvmName} obj= "%1" password= "%2:^&=&%"
 )
 
 :no_user

--- a/jwala-tomcat/src/main/resources/data/templates/install-service-jvm.bat.tpl
+++ b/jwala-tomcat/src/main/resources/data/templates/install-service-jvm.bat.tpl
@@ -37,9 +37,9 @@ IF "%ERRORLEVEL%" NEQ "0" (
 if %1=="" goto :no_user
 
 if "%2"=="""" (
-	SC CONFIG ${jvm.jvmName} obj= "%1"
+	SC CONFIG ${jvm.jvmName} obj= "%~1"
 ) else (
-	SC CONFIG ${jvm.jvmName} obj= "%1" password= "%2"
+	SC CONFIG ${jvm.jvmName} obj= "%~1" password= "%2"
 )
 
 :no_user

--- a/jwala-tomcat/src/main/resources/data/templates/install-service-jvm.bat.tpl
+++ b/jwala-tomcat/src/main/resources/data/templates/install-service-jvm.bat.tpl
@@ -40,9 +40,9 @@ IF "%ERRORLEVEL%" NEQ "0" (
 if %svc_username%=="" goto :no_user
 
 if %svc_password%=="" (
-	SC CONFIG ${jvm.jvmName} obj= %svc_username%
+	SC CONFIG ${jvm.jvmName} obj= "%svc_username%"
 ) else (
-	SC CONFIG ${jvm.jvmName} obj= %svc_username% password= %svc_password%
+	SC CONFIG ${jvm.jvmName} obj= "%svc_username%" password= "%svc_password%"
 )
 
 :no_user

--- a/jwala-tomcat/src/main/resources/data/templates/install-service-jvm.bat.tpl
+++ b/jwala-tomcat/src/main/resources/data/templates/install-service-jvm.bat.tpl
@@ -39,7 +39,7 @@ if %1=="" goto :no_user
 if "%2"=="""" (
 	SC CONFIG ${jvm.jvmName} obj= "%1"
 ) else (
-	SC CONFIG ${jvm.jvmName} obj= "%1" password= "%2:^&=&%"
+	SC CONFIG ${jvm.jvmName} obj= "%1" password= "%2"
 )
 
 :no_user


### PR DESCRIPTION
The JVM service fails to install when an account is used that has an ampersand in the password.

- Fix the JvmCommandFactory to put quotes around the password when creating the remote command.
- Escape any ampersands in the password from the install service bash script
- In the JVM batch file that installs the Windows service, escape the password in the conditional where it check for an empty password so the script doesn't fail before trying to install the service (WINDOWS NT SERVICE test case)