### PR TITLE
Do not show properties with null values on serialization

### DIFF
--- a/jwala-common/src/main/java/com/cerner/jwala/common/domain/model/resource/Entity.java
+++ b/jwala-common/src/main/java/com/cerner/jwala/common/domain/model/resource/Entity.java
@@ -2,12 +2,14 @@ package com.cerner.jwala.common.domain.model.resource;
 
 import org.codehaus.jackson.annotate.JsonCreator;
 import org.codehaus.jackson.annotate.JsonProperty;
+import org.codehaus.jackson.map.annotate.JsonSerialize;
 
 /**
  * Resource entity that wraps type, group and target
  *
  * Created by Jedd Cuison on 3/30/2016
  */
+@JsonSerialize(include = JsonSerialize.Inclusion.NON_NULL)
 public class Entity {
     private final String type;
     private final String group;

--- a/jwala-common/src/main/java/com/cerner/jwala/common/domain/model/resource/ResourceTemplateMetaData.java
+++ b/jwala-common/src/main/java/com/cerner/jwala/common/domain/model/resource/ResourceTemplateMetaData.java
@@ -12,6 +12,7 @@ import org.codehaus.jackson.map.annotate.JsonSerialize;
  * <p>
  * Created by Jedd Cuison on 3/30/2016.
  */
+@JsonSerialize(include = JsonSerialize.Inclusion.NON_NULL)
 public class ResourceTemplateMetaData {
     private final String templateName;
 


### PR DESCRIPTION
When creating a new resource, the meta data should only display properties that have values. The null values properties generally comes from the entity property which is only there for backward compatibility. In due time this property will also be refactored out. 