### PR TITLE
Mask password (if there are any) from Jsch output and its debug log

### DIFF
--- a/jwala-common/src/main/java/com/cerner/jwala/common/jsch/impl/JschServiceImpl.java
+++ b/jwala-common/src/main/java/com/cerner/jwala/common/jsch/impl/JschServiceImpl.java
@@ -12,6 +12,7 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.text.MessageFormat;
 
+import com.cerner.jwala.common.scrubber.ScrubberService;
 import org.apache.commons.pool2.impl.GenericKeyedObjectPool;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -59,6 +60,9 @@ public class JschServiceImpl implements JschService {
 
     @Autowired
     private GenericKeyedObjectPool<ChannelSessionKey, Channel> channelPool;
+
+    @Autowired
+    private ScrubberService scrubberService;
 
     @Override
     public RemoteCommandReturnInfo runShellCommand(RemoteSystemConnection remoteSystemConnection, String command, long timeout) {
@@ -126,7 +130,7 @@ public class JschServiceImpl implements JschService {
             LOGGER.debug("session connected");
             channel = (ChannelExec) session.openChannel(ChannelType.EXEC.getChannelType());
 
-            LOGGER.debug("Executing command \"{}\"", command);
+            LOGGER.debug("Executing command \"{}\"", scrubberService.scrub(command));
             channel.setCommand(command.getBytes(StandardCharsets.UTF_8));
 
             LOGGER.debug("channel {} connecting...", channel.getId());
@@ -167,7 +171,7 @@ public class JschServiceImpl implements JschService {
     private RemoteCommandReturnInfo getExecRemoteCommandReturnInfo(final ChannelExec channelExec, final long timeout)
             throws IOException, JSchException {
 
-        final String output = readExecRemoteOutput(channelExec, timeout);
+        final String output = scrubberService.scrub(readExecRemoteOutput(channelExec, timeout));
         LOGGER.debug("remote output = {}", output);
 
         String errorOutput = null;

--- a/jwala-common/src/main/java/com/cerner/jwala/common/scrubber/KeywordSetWrapperService.java
+++ b/jwala-common/src/main/java/com/cerner/jwala/common/scrubber/KeywordSetWrapperService.java
@@ -1,0 +1,18 @@
+package com.cerner.jwala.common.scrubber;
+
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArraySet;
+
+/**
+ * Created by Jedd Cuison on 6/16/2017
+ */
+public interface KeywordSetWrapperService {
+
+    Set<String> copyOnWriteArraySet = new CopyOnWriteArraySet<>();
+
+    void add(String obj);
+
+    void remove(String obj);
+
+    void clear();
+}

--- a/jwala-common/src/main/java/com/cerner/jwala/common/scrubber/ScrubberService.java
+++ b/jwala-common/src/main/java/com/cerner/jwala/common/scrubber/ScrubberService.java
@@ -1,0 +1,10 @@
+package com.cerner.jwala.common.scrubber;
+
+/**
+ * Created by Jedd Cuison on 6/20/2017
+ */
+public interface ScrubberService {
+
+    String scrub(String raw);
+
+}

--- a/jwala-common/src/main/java/com/cerner/jwala/common/scrubber/impl/JvmWinSvcAcctPasswordScrubberServiceImpl.java
+++ b/jwala-common/src/main/java/com/cerner/jwala/common/scrubber/impl/JvmWinSvcAcctPasswordScrubberServiceImpl.java
@@ -1,0 +1,32 @@
+package com.cerner.jwala.common.scrubber.impl;
+
+import com.cerner.jwala.common.domain.model.ssh.DecryptPassword;
+import com.cerner.jwala.common.scrubber.KeywordSetWrapperService;
+import com.cerner.jwala.common.scrubber.ScrubberService;
+import org.springframework.stereotype.Service;
+
+/**
+ * Created by Jedd Cuison on 6/20/2017
+ */
+@Service
+public class JvmWinSvcAcctPasswordScrubberServiceImpl implements ScrubberService {
+
+    private static final String REPLACEMENT = "********";
+
+    private final DecryptPassword decryptor;
+
+    public JvmWinSvcAcctPasswordScrubberServiceImpl(final DecryptPassword decryptor) {
+        this.decryptor = decryptor;
+    }
+
+    @Override
+    public String scrub(final String raw) {
+        for (final String password : KeywordSetWrapperService.copyOnWriteArraySet) {
+            final String scrubbedStr = raw.replaceAll(decryptor.decrypt(password), REPLACEMENT);
+            if (!raw.equalsIgnoreCase(scrubbedStr)) {
+                return scrubbedStr;
+            }
+        }
+        return raw;
+    }
+}

--- a/jwala-common/src/test/java/com/cerner/jwala/common/jsch/impl/JschServiceImplTest.java
+++ b/jwala-common/src/test/java/com/cerner/jwala/common/jsch/impl/JschServiceImplTest.java
@@ -6,6 +6,7 @@ import com.cerner.jwala.common.exec.RemoteSystemConnection;
 import com.cerner.jwala.common.jsch.JschService;
 import com.cerner.jwala.common.jsch.JschServiceException;
 import com.cerner.jwala.common.jsch.RemoteCommandReturnInfo;
+import com.cerner.jwala.common.scrubber.ScrubberService;
 import com.jcraft.jsch.*;
 import org.apache.commons.pool2.impl.GenericKeyedObjectPool;
 import org.junit.Before;
@@ -122,6 +123,8 @@ public class JschServiceImplTest {
         @SuppressWarnings("unchecked")
         public static final GenericKeyedObjectPool<ChannelSessionKey, Channel> mockPool = mock(GenericKeyedObjectPool.class);
 
+        public static final ScrubberService MOCK_SCRUBBER_SERVICE = mock(ScrubberService.class);
+
         @Bean
         public JSch getMockJsch() {
             return mockJsch;
@@ -130,6 +133,11 @@ public class JschServiceImplTest {
         @Bean
         public static GenericKeyedObjectPool<ChannelSessionKey, Channel> getMockPool() {
             return mockPool;
+        }
+
+        @Bean
+        public ScrubberService getScrubberService() {
+            return MOCK_SCRUBBER_SERVICE;
         }
 
         @Bean

--- a/jwala-common/src/test/java/com/cerner/jwala/common/scrubber/impl/JvmWinSvcAcctPasswordScrubberServiceImplTest.java
+++ b/jwala-common/src/test/java/com/cerner/jwala/common/scrubber/impl/JvmWinSvcAcctPasswordScrubberServiceImplTest.java
@@ -1,0 +1,37 @@
+package com.cerner.jwala.common.scrubber.impl;
+
+import com.cerner.jwala.common.domain.model.ssh.DecryptPassword;
+import com.cerner.jwala.common.scrubber.KeywordSetWrapperService;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import static org.junit.Assert.*;
+
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+/**
+ * Created by Jedd Cuison on 6/20/2017
+ */
+public class JvmWinSvcAcctPasswordScrubberServiceImplTest {
+
+    private JvmWinSvcAcctPasswordScrubberServiceImpl jvmWinSvcAcctPasswordScrubberService;
+
+    @Mock
+    private DecryptPassword mockDecryptPassword;
+
+    @Before
+    public void setUp() {
+        initMocks(this);
+        KeywordSetWrapperService.copyOnWriteArraySet.clear();
+        KeywordSetWrapperService.copyOnWriteArraySet.add("secret");
+        jvmWinSvcAcctPasswordScrubberService = new JvmWinSvcAcctPasswordScrubberServiceImpl(mockDecryptPassword);
+    }
+
+    @Test
+    public void testScrub() throws Exception {
+        when(mockDecryptPassword.decrypt("secret")).thenReturn("secret");
+        final String result = jvmWinSvcAcctPasswordScrubberService.scrub("password = secret");
+        assertEquals("password = ********", result);
+    }
+}

--- a/jwala-common/src/test/java/com/cerner/jwala/common/scrubber/impl/JvmWinSvcAcctPasswordScrubberServiceImplTest.java
+++ b/jwala-common/src/test/java/com/cerner/jwala/common/scrubber/impl/JvmWinSvcAcctPasswordScrubberServiceImplTest.java
@@ -17,6 +17,13 @@ public class JvmWinSvcAcctPasswordScrubberServiceImplTest {
 
     private JvmWinSvcAcctPasswordScrubberServiceImpl jvmWinSvcAcctPasswordScrubberService;
 
+    private static String TEST_RAW_STR_1 = "D:/cygwin64/home/someUser>set svc_password=secret ";
+    private static String SCRUBBED_STR_1 = "D:/cygwin64/home/someUser>set svc_password=******** ";
+    private static String TEST_RAW_STR_2 = "Executing command \"~/.jwala/SOME-SERVER/install-service.sh SOME-SERVER " +
+            "D:/ctp/app/instances apache-tomcat-7.0.55 \"the-user\" secret \"";
+    private static String SCRUBBED_STR_2 = "Executing command \"~/.jwala/SOME-SERVER/install-service.sh SOME-SERVER " +
+            "D:/ctp/app/instances apache-tomcat-7.0.55 \"the-user\" ******** \"";
+
     @Mock
     private DecryptPassword mockDecryptPassword;
 
@@ -29,9 +36,16 @@ public class JvmWinSvcAcctPasswordScrubberServiceImplTest {
     }
 
     @Test
-    public void testScrub() throws Exception {
+    public void testScrubRawStr1() {
         when(mockDecryptPassword.decrypt("secret")).thenReturn("secret");
-        final String result = jvmWinSvcAcctPasswordScrubberService.scrub("password = secret");
-        assertEquals("password = ********", result);
+        final String result = jvmWinSvcAcctPasswordScrubberService.scrub(TEST_RAW_STR_1);
+        assertEquals(SCRUBBED_STR_1, result);
+    }
+
+    @Test
+    public void testScrubRawStr2() {
+        when(mockDecryptPassword.decrypt("secret")).thenReturn("secret");
+        final String result = jvmWinSvcAcctPasswordScrubberService.scrub(TEST_RAW_STR_2);
+        assertEquals(SCRUBBED_STR_2, result);
     }
 }

--- a/jwala-services/src/main/java/com/cerner/jwala/service/configuration/service/AemServiceConfiguration.java
+++ b/jwala-services/src/main/java/com/cerner/jwala/service/configuration/service/AemServiceConfiguration.java
@@ -7,6 +7,7 @@ import com.cerner.jwala.common.FileUtility;
 import com.cerner.jwala.common.domain.model.id.Identifier;
 import com.cerner.jwala.common.domain.model.jvm.Jvm;
 import com.cerner.jwala.common.domain.model.jvm.JvmState;
+import com.cerner.jwala.common.domain.model.ssh.DecryptPassword;
 import com.cerner.jwala.common.domain.model.ssh.SshConfiguration;
 import com.cerner.jwala.common.domain.model.state.CurrentState;
 import com.cerner.jwala.common.domain.model.webserver.WebServer;
@@ -113,7 +114,8 @@ import java.util.concurrent.ThreadPoolExecutor;
         "com.cerner.jwala.control.jvm.command",
         "com.cerner.jwala.control.webserver.command",
         "com.cerner.jwala.commandprocessor.impl.jsch",
-        "com.cerner.jwala.control.command.common"})
+        "com.cerner.jwala.control.command.common",
+        "com.cerner.jwala.common.scrubber.impl"})
 public class AemServiceConfiguration {
 
     @Autowired
@@ -415,5 +417,10 @@ public class AemServiceConfiguration {
     @Bean
     public ApplicationContextListener getApplicationContextListener() {
         return new ApplicationContextListener();
+    }
+
+    @Bean
+    public DecryptPassword getDecryptPassword() {
+        return new DecryptPassword();
     }
 }

--- a/jwala-services/src/main/java/com/cerner/jwala/service/impl/spring/component/JvmWinSvcPwdStoreServiceImpl.java
+++ b/jwala-services/src/main/java/com/cerner/jwala/service/impl/spring/component/JvmWinSvcPwdStoreServiceImpl.java
@@ -1,0 +1,41 @@
+package com.cerner.jwala.service.impl.spring.component;
+
+import com.cerner.jwala.common.domain.model.jvm.Jvm;
+import com.cerner.jwala.common.scrubber.KeywordSetWrapperService;
+import com.cerner.jwala.persistence.service.JvmPersistenceService;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+/**
+ * Created by Jedd Cuison on 6/19/2017
+ */
+@Service
+public class JvmWinSvcPwdStoreServiceImpl implements KeywordSetWrapperService {
+
+    public JvmWinSvcPwdStoreServiceImpl(final JvmPersistenceService jvmPersistenceService) {
+        // Populate the map of items to remove in the logs
+        final List<Jvm> jvms = jvmPersistenceService.getJvms();
+        for (final Jvm jvm: jvms) {
+            if (StringUtils.isNotEmpty(jvm.getEncryptedPassword())) {
+                copyOnWriteArraySet.add(jvm.getEncryptedPassword());
+            }
+        }
+    }
+
+    @Override
+    public void add(final String password) {
+        copyOnWriteArraySet.add(password);
+    }
+
+    @Override
+    public void remove(final String password) {
+        copyOnWriteArraySet.remove(password);
+    }
+
+    @Override
+    public void clear() {
+        copyOnWriteArraySet.clear();
+    }
+}

--- a/jwala-services/src/main/java/com/cerner/jwala/service/jvm/impl/JvmServiceImpl.java
+++ b/jwala-services/src/main/java/com/cerner/jwala/service/jvm/impl/JvmServiceImpl.java
@@ -23,6 +23,7 @@ import com.cerner.jwala.common.properties.ApplicationProperties;
 import com.cerner.jwala.common.properties.PropertyKeys;
 import com.cerner.jwala.common.request.group.AddJvmToGroupRequest;
 import com.cerner.jwala.common.request.jvm.*;
+import com.cerner.jwala.common.scrubber.KeywordSetWrapperService;
 import com.cerner.jwala.exception.CommandFailureException;
 import com.cerner.jwala.persistence.jpa.domain.resource.config.template.JpaJvmConfigTemplate;
 import com.cerner.jwala.persistence.jpa.service.exception.NonRetrievableResourceTemplateContentException;
@@ -91,6 +92,9 @@ public class JvmServiceImpl implements JvmService {
 
     @Autowired
     private WebServerPersistenceService webServerPersistenceService;
+
+    @Autowired
+    private KeywordSetWrapperService keywordSetWrapperService;
 
     public JvmServiceImpl(final JvmPersistenceService jvmPersistenceService,
                           final GroupPersistenceService groupPersistenceService,
@@ -173,6 +177,11 @@ public class JvmServiceImpl implements JvmService {
                 LOGGER.warn("Multiple groups were associated with the JVM, but the JVM was created using the templates from group "
                         + parentGroup.getName());
             }
+        }
+
+        if (StringUtils.isNotEmpty(jvm.getEncryptedPassword())) {
+            keywordSetWrapperService.add(jvm.getEncryptedPassword());
+            LOGGER.debug("Added jvm win svc password from password store");
         }
 
         return jvm;
@@ -282,7 +291,21 @@ public class JvmServiceImpl implements JvmService {
 
         addJvmToGroups(updateJvmRequest.getAssignmentCommands());
 
-        return jvmPersistenceService.updateJvm(updateJvmRequest, updateJvmPassword);
+        final Jvm jvm = jvmPersistenceService.updateJvm(updateJvmRequest, updateJvmPassword);
+
+        // Remove the jvm Windows service password from the password store
+        if (StringUtils.isNotEmpty(originalJvm.getEncryptedPassword())) {
+            keywordSetWrapperService.remove(originalJvm.getEncryptedPassword());
+            LOGGER.debug("Removed jvm win svc password from password store");
+        }
+
+        // Add the jvm Windows service password to the password store
+        if (StringUtils.isNotEmpty(jvm.getEncryptedPassword())) {
+            keywordSetWrapperService.add(jvm.getEncryptedPassword());
+            LOGGER.debug("Added jvm win svc password from password store");
+        }
+
+        return jvm;
     }
 
     private void validateUpdateJvm(UpdateJvmRequest updateJvmRequest) {
@@ -343,6 +366,11 @@ public class JvmServiceImpl implements JvmService {
         }
 
         jvmPersistenceService.removeJvm(id);
+
+        if (StringUtils.isNotEmpty(jvm.getEncryptedPassword())) {
+            keywordSetWrapperService.remove(jvm.getEncryptedPassword());
+            LOGGER.debug("Removed jvm win svc password from password store");
+        }
     }
 
     @Override

--- a/jwala-services/src/test/java/com/cerner/jwala/service/impl/spring/component/JvmWinSvcPwdStoreServiceImplTest.java
+++ b/jwala-services/src/test/java/com/cerner/jwala/service/impl/spring/component/JvmWinSvcPwdStoreServiceImplTest.java
@@ -1,0 +1,58 @@
+package com.cerner.jwala.service.impl.spring.component;
+
+import com.cerner.jwala.common.domain.model.jvm.Jvm;
+import com.cerner.jwala.common.scrubber.KeywordSetWrapperService;
+import com.cerner.jwala.persistence.service.JvmPersistenceService;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+/**
+ * Created by Jedd Cuison on 6/20/2017
+ */
+public class JvmWinSvcPwdStoreServiceImplTest {
+
+    private JvmWinSvcPwdStoreServiceImpl jvmWinSvcPwdStoreService;
+
+    @Mock
+    private JvmPersistenceService mockJvmPersistenceService;
+
+    @Mock
+    private Jvm mockJvm;
+
+    @Before
+    public void setUp() throws Exception {
+        initMocks(this);
+        KeywordSetWrapperService.copyOnWriteArraySet.clear();
+        final List<Jvm> mockJvms = new ArrayList<>();
+        when(mockJvm.getEncryptedPassword()).thenReturn("$#$%#$%$#^&&==");
+        mockJvms.add(mockJvm);
+        when(mockJvmPersistenceService.getJvms()).thenReturn(mockJvms);
+        jvmWinSvcPwdStoreService = new JvmWinSvcPwdStoreServiceImpl(mockJvmPersistenceService);
+    }
+
+    @Test
+    public void testAdd() throws Exception {
+        jvmWinSvcPwdStoreService.add("@@@!!!@@@@!!==");
+        assertEquals(2, KeywordSetWrapperService.copyOnWriteArraySet.size());
+    }
+
+    @Test
+    public void testRemove() throws Exception {
+        jvmWinSvcPwdStoreService.remove("$#$%#$%$#^&&==");
+        assertEquals(0, KeywordSetWrapperService.copyOnWriteArraySet.size());
+    }
+
+    @Test
+    public void testClear() throws Exception {
+        jvmWinSvcPwdStoreService.clear();
+        assertEquals(0, KeywordSetWrapperService.copyOnWriteArraySet.size());
+    }
+}

--- a/jwala-services/src/test/java/com/cerner/jwala/service/jvm/impl/JvmServiceImplTest.java
+++ b/jwala-services/src/test/java/com/cerner/jwala/service/jvm/impl/JvmServiceImplTest.java
@@ -25,6 +25,7 @@ import com.cerner.jwala.common.properties.ApplicationProperties;
 import com.cerner.jwala.common.properties.PropertyKeys;
 import com.cerner.jwala.common.request.group.AddJvmToGroupRequest;
 import com.cerner.jwala.common.request.jvm.*;
+import com.cerner.jwala.common.scrubber.KeywordSetWrapperService;
 import com.cerner.jwala.control.AemControl;
 import com.cerner.jwala.exception.CommandFailureException;
 import com.cerner.jwala.persistence.jpa.type.EventType;
@@ -40,6 +41,7 @@ import com.cerner.jwala.service.binarydistribution.BinaryDistributionLockManager
 import com.cerner.jwala.service.binarydistribution.BinaryDistributionService;
 import com.cerner.jwala.service.group.GroupService;
 import com.cerner.jwala.service.group.GroupStateNotificationService;
+import com.cerner.jwala.service.impl.spring.component.JvmWinSvcPwdStoreServiceImpl;
 import com.cerner.jwala.service.jvm.JvmControlService;
 import com.cerner.jwala.service.jvm.JvmService;
 import com.cerner.jwala.service.jvm.JvmStateService;
@@ -359,6 +361,7 @@ public class JvmServiceImplTest extends VerificationBehaviorSupport {
         when(updateJvmRequest.getNewJvmName()).thenReturn("TestJvm");
         when(Config.mockJvmPersistenceService.findJvmByExactName(anyString())).thenThrow(NoResultException.class);
         when(Config.mockWebServerPersistenceService.findWebServerByName(anyString())).thenThrow(NoResultException.class);
+        when(Config.mockJvmPersistenceService.updateJvm(updateJvmRequest, true)).thenReturn(mockJvm);
 
         jvmService.updateJvm(updateJvmRequest, true);
 
@@ -422,6 +425,7 @@ public class JvmServiceImplTest extends VerificationBehaviorSupport {
         when(updateJvmRequest.getNewJvmName()).thenReturn(newjvmName);
         when(Config.mockWebServerPersistenceService.findWebServerByName(anyString())).thenThrow(NoResultException.class);
         when(Config.mockJvmPersistenceService.findJvmByExactName(anyString())).thenThrow(NoResultException.class);
+        when(Config.mockJvmPersistenceService.updateJvm(updateJvmRequest, true)).thenReturn(mockJvm);
         jvmService.updateJvm(updateJvmRequest, true);
         verify(updateJvmRequest, times(1)).validate();
         verify(Config.mockJvmPersistenceService, times(1)).updateJvm(updateJvmRequest, true);
@@ -1189,6 +1193,11 @@ public class JvmServiceImplTest extends VerificationBehaviorSupport {
         @Bean
         public static HistoryFacadeService getMockHistoryFacadeService() {
             return mockHistoryFacadeService;
+        }
+
+        @Bean
+        public static KeywordSetWrapperService getJvmWinSvcPwdCollectionService() {
+            return new JvmWinSvcPwdStoreServiceImpl(mockJvmPersistenceService);
         }
 
         @Bean


### PR DESCRIPTION
Mask Jsch output and the command string before logging to prevent clear text password from filtering down the classes that uses the Jsch service and from showing up in the logs.