### PR TITLE
Integrate Apache HTTPD 2.4.26 into stp-toc and stp-healthcheck cookbook

### DIFF
--- a/jwala-common/src/main/java/com/cerner/jwala/common/domain/model/fault/FaultType.java
+++ b/jwala-common/src/main/java/com/cerner/jwala/common/domain/model/fault/FaultType.java
@@ -156,7 +156,9 @@ public enum FaultType implements MessageResponseStatus {
 
     NAME_INVALID_SPECIAL_CHARACTERS("AEM76", "NameInvalidSpecialCharacters"),
 
-    MEDIA_NOT_FOUND("AEM77", "MediaNotFound");
+    MEDIA_NOT_FOUND("AEM77", "MediaNotFound"),
+
+    RESOURCE_NO_ATTACHMENT_EXCEPTION("AEM78", "ResourceNoAttachmentException");
 
     private final String faultCode;
     private final String faultMessage;

--- a/jwala-services/src/test/java/com/cerner/jwala/service/balancermanager/BalanceManagerServiceImplTest.java
+++ b/jwala-services/src/test/java/com/cerner/jwala/service/balancermanager/BalanceManagerServiceImplTest.java
@@ -506,18 +506,22 @@ public class BalanceManagerServiceImplTest {
 
     /*
     * To make sure jwala can parse different versions of apache httpd balancer manager html page
+    * such as 2.4.10, 2.4.20 and 2.4.26
     * */
     @Test
     public void testFindBalancers(){
-        final String testString = "<h3>LoadBalancer Status for <a href='/balancer-manager?b=lb-health-check-4.0&amp;nonce=0d72ebfa-3476-df48-aa89-008c9e7ad89b'>balancer://lb-health-check-4.0</a> [pb616726e_lb_health_check_4_0]</h3>\n" +
+        final String testString = "<h3>LoadBalancer Status for <a href='/balancer-manager?b=lb-health-check-2.4-26&amp;nonce=0d72ebfa-3476-df48-aa89-008c9e7ad89b'>balancer://lb-health-check-2.4-26</a> [pb616726e_lb_health_check_4_0]</h3>\n" +
                 "\n" +
-                "<h3>LoadBalancer Status for <a href=\"/balancer-manager?b=lb-health-check-4.1&nonce=b63797ed-18be-0d4c-8e80-98b8d04d6f1e\">balancer://lb-health-check-4.1</a> [p921348eb_lb_health_check_4_1]</h3>";
+                "<h3>LoadBalancer Status for <a href=\"/balancer-manager?b=lb-health-check-2.4-20&nonce=b63797ed-18be-0d4c-8e80-98b8d04d6f1e\">balancer://lb-health-check-2.4-20</a> [p921348eb_lb_health_check_4_1]</h3>\n" +
+                "\n" +
+                "<h3>LoadBalancer Status for <a href=\"/balancer-manager?b=lb-health-check-2.4-10&nonce=b5b5111b-132f-1249-8e4c-6bf18cf81caa\">balancer://lb-health-check-2.4-10</a> [p9e2f1fe1_lb_tntin_4_1_tntin]</h3>";
         BalancerManagerHtmlParser balancerManagerHtmlParser = new BalancerManagerHtmlParser();
         Map<String, String> balancers = balancerManagerHtmlParser.findBalancers(testString);
-        assertTrue(balancers.size() == 2);
+        assertTrue(balancers.size() == 3);
         Map<String, String> expectedBalancers = new HashMap<>();
-        expectedBalancers.put("lb-health-check-4.0","0d72ebfa-3476-df48-aa89-008c9e7ad89b");
-        expectedBalancers.put("lb-health-check-4.1","b63797ed-18be-0d4c-8e80-98b8d04d6f1e");
+        expectedBalancers.put("lb-health-check-2.4-26","0d72ebfa-3476-df48-aa89-008c9e7ad89b");
+        expectedBalancers.put("lb-health-check-2.4-20","b63797ed-18be-0d4c-8e80-98b8d04d6f1e");
+        expectedBalancers.put("lb-health-check-2.4-10","b5b5111b-132f-1249-8e4c-6bf18cf81caa");
         assertTrue(balancers.equals(expectedBalancers));
     }
 }

--- a/jwala-services/src/test/java/com/cerner/jwala/service/balancermanager/BalanceManagerServiceImplTest.java
+++ b/jwala-services/src/test/java/com/cerner/jwala/service/balancermanager/BalanceManagerServiceImplTest.java
@@ -31,6 +31,7 @@ import java.io.ByteArrayInputStream;
 import java.util.*;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.*;
 import static org.mockito.Mockito.*;
 import static org.mockito.MockitoAnnotations.initMocks;
@@ -501,5 +502,22 @@ public class BalanceManagerServiceImplTest {
     public void testDrainUserJvmMultiApp() throws Exception {
 
 
+    }
+
+    /*
+    * To make sure jwala can parse different versions of apache httpd balancer manager html page
+    * */
+    @Test
+    public void testFindBalancers(){
+        final String testString = "<h3>LoadBalancer Status for <a href='/balancer-manager?b=lb-health-check-4.0&amp;nonce=0d72ebfa-3476-df48-aa89-008c9e7ad89b'>balancer://lb-health-check-4.0</a> [pb616726e_lb_health_check_4_0]</h3>\n" +
+                "\n" +
+                "<h3>LoadBalancer Status for <a href=\"/balancer-manager?b=lb-health-check-4.1&nonce=b63797ed-18be-0d4c-8e80-98b8d04d6f1e\">balancer://lb-health-check-4.1</a> [p921348eb_lb_health_check_4_1]</h3>";
+        BalancerManagerHtmlParser balancerManagerHtmlParser = new BalancerManagerHtmlParser();
+        Map<String, String> balancers = balancerManagerHtmlParser.findBalancers(testString);
+        assertTrue(balancers.size() == 2);
+        Map<String, String> expectedBalancers = new HashMap<>();
+        expectedBalancers.put("lb-health-check-4.0","0d72ebfa-3476-df48-aa89-008c9e7ad89b");
+        expectedBalancers.put("lb-health-check-4.1","b63797ed-18be-0d4c-8e80-98b8d04d6f1e");
+        assertTrue(balancers.equals(expectedBalancers));
     }
 }

--- a/jwala-webservices/src/main/java/com/cerner/jwala/ws/rest/v1/service/resource/impl/ResourceServiceRestImpl.java
+++ b/jwala-webservices/src/main/java/com/cerner/jwala/ws/rest/v1/service/resource/impl/ResourceServiceRestImpl.java
@@ -134,10 +134,9 @@ public class ResourceServiceRestImpl implements ResourceServiceRest {
 
         if (attachments == null || !isExternalProperty && attachments.size() == 0 ) {
             LOGGER.error("Expected non-empty attachments. Returning without creating Resource.");
-            return Response.status(Response.Status.BAD_REQUEST).build();
-        }
-
-        if (attachments != null){
+            return ResponseBuilder.notOk(Response.Status.INTERNAL_SERVER_ERROR,
+                    new FaultCodeException(FaultType.RESOURCE_NO_ATTACHMENT_EXCEPTION, "There is no attachment when try to create resource."));
+        } else {
             LOGGER.debug("attachments.size() " + attachments.size());
             for (final Attachment attachment : attachments) {
                 LOGGER.debug("attachment.getDataHandler().getName(): " + attachment.getDataHandler().getName() +

--- a/jwala-webservices/src/main/java/com/cerner/jwala/ws/rest/v1/service/resource/impl/ResourceServiceRestImpl.java
+++ b/jwala-webservices/src/main/java/com/cerner/jwala/ws/rest/v1/service/resource/impl/ResourceServiceRestImpl.java
@@ -132,10 +132,17 @@ public class ResourceServiceRestImpl implements ResourceServiceRest {
         // TODO pass down single param from UI to designate external properties
         final boolean isExternalProperty = createResourceParam.getGroup() == null && createResourceParam.getJvm() == null && createResourceParam.getWebApp() == null && createResourceParam.getWebServer() == null;
 
-        if (attachments == null || !isExternalProperty && attachments.size() != CREATE_RESOURCE_ATTACHMENT_SIZE) {
-            return ResponseBuilder.notOk(Response.Status.INTERNAL_SERVER_ERROR, new FaultCodeException(
-                    FaultType.INVALID_NUMBER_OF_ATTACHMENTS,
-                    "Invalid number of attachments! " + CREATE_RESOURCE_ATTACHMENT_SIZE + " attachments is expected by the service."));
+        if (attachments == null || !isExternalProperty && attachments.size() == 0 ) {
+            LOGGER.error("Expected non-empty attachments. Returning without creating Resource.");
+            return Response.status(Response.Status.BAD_REQUEST).build();
+        }
+
+        if (attachments != null){
+            LOGGER.debug("attachments.size() " + attachments.size());
+            for (final Attachment attachment : attachments) {
+                LOGGER.debug("attachment.getDataHandler().getName(): " + attachment.getDataHandler().getName() +
+                        " attachment.getHeader(\"Content-Type\"): " + attachment.getHeader("Content-Type"));
+            }
         }
 
         try {
@@ -143,6 +150,11 @@ public class ResourceServiceRestImpl implements ResourceServiceRest {
             BufferedInputStream bufferedInputStream = null;
             String templateName = null;
             for (final Attachment attachment : attachments) {
+                // when using the REST API from Chef a null attachment gets added somewhere between the execute_rest and here
+                if (attachment.getDataHandler().getName() == null ){
+                    LOGGER.debug("attachment.getDataHandler().getName() is null");
+                    continue;
+                }
                 if (attachment.getHeader("Content-Type") == null) {
                     metaDataMap.put(attachment.getDataHandler().getName(),
                             IOUtils.toString(attachment.getDataHandler().getInputStream(), Charset.defaultCharset()));

--- a/jwala-webservices/src/test/java/com/cerner/jwala/ws/rest/v1/service/resource/impl/ResourceServiceRestImplTest.java
+++ b/jwala-webservices/src/test/java/com/cerner/jwala/ws/rest/v1/service/resource/impl/ResourceServiceRestImplTest.java
@@ -186,7 +186,7 @@ public class ResourceServiceRestImplTest {
         CreateResourceParam createResourceParam = new CreateResourceParam();
         createResourceParam.setJvm("sampleJvm");
         final Response response = cut.createResource("httpd.conf", createResourceParam, attachmentList);
-        assertEquals("AEM61", ((ApplicationResponse) response.getEntity()).getMsgCode());
+        assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
     }
 
     @Test
@@ -194,7 +194,7 @@ public class ResourceServiceRestImplTest {
         CreateResourceParam createResourceParam = new CreateResourceParam();
         createResourceParam.setJvm("sampleJvm");
         final Response response = cut.createResource("httpd.conf", createResourceParam, null);
-        assertEquals("AEM61", ((ApplicationResponse) response.getEntity()).getMsgCode());
+        assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
     }
 
     @Test

--- a/jwala-webservices/src/test/java/com/cerner/jwala/ws/rest/v1/service/resource/impl/ResourceServiceRestImplTest.java
+++ b/jwala-webservices/src/test/java/com/cerner/jwala/ws/rest/v1/service/resource/impl/ResourceServiceRestImplTest.java
@@ -186,7 +186,7 @@ public class ResourceServiceRestImplTest {
         CreateResourceParam createResourceParam = new CreateResourceParam();
         createResourceParam.setJvm("sampleJvm");
         final Response response = cut.createResource("httpd.conf", createResourceParam, attachmentList);
-        assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
+        assertEquals("AEM78", ((ApplicationResponse) response.getEntity()).getMsgCode());
     }
 
     @Test
@@ -194,7 +194,7 @@ public class ResourceServiceRestImplTest {
         CreateResourceParam createResourceParam = new CreateResourceParam();
         createResourceParam.setJvm("sampleJvm");
         final Response response = cut.createResource("httpd.conf", createResourceParam, null);
-        assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
+        assertEquals("AEM78", ((ApplicationResponse) response.getEntity()).getMsgCode());
     }
 
     @Test


### PR DESCRIPTION
Make sure jwala drain feature can handle multiple version of apache httpd such as 2.4.10, 2.4.20 and 2.4.26. 

*. Update the balancer manager class to parse any of known apache httpd html 