### PR TITLE
Deprecate  "remote.jwala.data.dir"

### DIFF
--- a/jwala-common/src/main/java/com/cerner/jwala/common/properties/PropertyKeys.java
+++ b/jwala-common/src/main/java/com/cerner/jwala/common/properties/PropertyKeys.java
@@ -21,7 +21,6 @@ public enum PropertyKeys {
     PATHS_RESOURCE_TEMPLATES("paths.resource-templates"),
     PORT("ssh.port"),
     PRIVATE_KEY_FILE("ssh.privateKeyFile"),
-    REMOTE_JAWALA_DATA_DIR("remote.jwala.data.dir"),
     REMOTE_PATHS_TOMCAT_ROOT_CORE("remote.paths.tomcat.root.core"),
     REMOTE_SCRIPT_DIR("remote.commands.user-scripts"),
     SCRIPTS_PATH("commands.scripts-path"),

--- a/jwala-integration-test/src/test/resources/postman/httpd.json
+++ b/jwala-integration-test/src/test/resources/postman/httpd.json
@@ -1,5 +1,5 @@
 {
-  "deployPath" : "${vars.'remote.jwala.data.dir'}/httpd/${webServer.name}",
+  "deployPath" : "${webServer.apacheHttpdMedia.remoteDir}/app/data/httpd/${webServer.name}",
   "templateName" : "HttpdConfTemplate.tpl",
   "deployFileName" : "httpd.conf",
   "contentType" : "text/plain",

--- a/jwala-integration-test/src/test/resources/postman/server.xml.tpl
+++ b/jwala-integration-test/src/test/resources/postman/server.xml.tpl
@@ -91,8 +91,8 @@
 
     <Connector 
       port="${jvm.httpsPort}"   
-	  SSLCertificateFile="${groups[0].jvms[0].tomcatMedia.remoteDir}/../data/security/id/${jvm.hostName}.cer"
-      SSLCertificateKeyFile="${groups[0].jvms[0].tomcatMedia.remoteDir}/../data/security/id/${jvm.hostName}.key"
+	  SSLCertificateFile="${jvm.tomcatMedia.remoteDir}/../data/security/id/${jvm.hostName}.cer"
+      SSLCertificateKeyFile="${jvm.tomcatMedia.remoteDir}/../data/security/id/${jvm.hostName}.key"
       SSLEnabled="true"
 
 	<% if (jvm.hostName.tokenize('.')[0].toLowerCase()=="usmlvv1cds0068") { %>

--- a/jwala-integration-test/src/test/resources/postman/server.xml.tpl
+++ b/jwala-integration-test/src/test/resources/postman/server.xml.tpl
@@ -90,9 +90,9 @@
     -->
 
     <Connector 
-      port="${jvm.httpsPort}" 
-	  SSLCertificateFile="${vars['remote.jwala.data.dir']}/../../app/data/security/id/${jvm.hostName}.cer"
-      SSLCertificateKeyFile="${vars['remote.jwala.data.dir']}/../../app/data/security/id/${jvm.hostName}.key"
+      port="${jvm.httpsPort}"   
+	  SSLCertificateFile="${groups[0].jvms[0].tomcatMedia.remoteDir}/../data/security/id/${jvm.hostName}.cer"
+      SSLCertificateKeyFile="${groups[0].jvms[0].tomcatMedia.remoteDir}/../data/security/id/${jvm.hostName}.key"
       SSLEnabled="true"
 
 	<% if (jvm.hostName.tokenize('.')[0].toLowerCase()=="usmlvv1cds0068") { %>

--- a/jwala-services/src/main/java/com/cerner/jwala/control/jvm/command/JvmCommandFactory.java
+++ b/jwala-services/src/main/java/com/cerner/jwala/control/jvm/command/JvmCommandFactory.java
@@ -41,6 +41,7 @@ import static com.cerner.jwala.control.AemControl.Properties.*;
 @Component
 public class JvmCommandFactory {
     private static final Logger LOGGER = LoggerFactory.getLogger(JvmCommandFactory.class);
+    public static final String SLASH_HEAP_DUMP = "/heap-dump";
 
     private HashMap<String, JvmCommand> commands;
 
@@ -184,9 +185,11 @@ public class JvmCommandFactory {
 
         final String dumpLiveStr = ApplicationProperties.getAsBoolean(PropertyKeys.JMAP_DUMP_LIVE_ENABLED.name()) ? "live," : "\"\"";
 
-        return new ExecCommand(getFullPathScript(jvm, scriptName), jvm.getJavaHome(),
-                ApplicationProperties.get(PropertyKeys.REMOTE_JAWALA_DATA_DIR), dumpFile, dumpLiveStr, jvmRootDir,
-                jvm.getJvmName());
+        final String heapDumpDir = jvm.getTomcatMedia().getRemoteDir().normalize().toString() + "/" + jvm.getJvmName() +
+                                   SLASH_HEAP_DUMP;
+
+        return new ExecCommand(getFullPathScript(jvm, scriptName), jvm.getJavaHome(), heapDumpDir, dumpFile,
+                               dumpLiveStr , jvmRootDir, jvm.getJvmName());
     }
 
     /**

--- a/jwala-services/src/main/java/com/cerner/jwala/control/jvm/command/JvmCommandFactory.java
+++ b/jwala-services/src/main/java/com/cerner/jwala/control/jvm/command/JvmCommandFactory.java
@@ -41,7 +41,6 @@ import static com.cerner.jwala.control.AemControl.Properties.*;
 @Component
 public class JvmCommandFactory {
     private static final Logger LOGGER = LoggerFactory.getLogger(JvmCommandFactory.class);
-    public static final String SLASH_HEAP_DUMP = "/heap-dump";
 
     private HashMap<String, JvmCommand> commands;
 
@@ -185,8 +184,7 @@ public class JvmCommandFactory {
 
         final String dumpLiveStr = ApplicationProperties.getAsBoolean(PropertyKeys.JMAP_DUMP_LIVE_ENABLED.name()) ? "live," : "\"\"";
 
-        final String heapDumpDir = jvm.getTomcatMedia().getRemoteDir().normalize().toString() + "/" + jvm.getJvmName() +
-                                   SLASH_HEAP_DUMP;
+        final String heapDumpDir = jvm.getTomcatMedia().getRemoteDir().normalize().toString() + "/" + jvm.getJvmName();
 
         return new ExecCommand(getFullPathScript(jvm, scriptName), jvm.getJavaHome(), heapDumpDir, dumpFile,
                                dumpLiveStr , jvmRootDir, jvm.getJvmName());

--- a/jwala-services/src/test/resources/managerXml/vars.properties
+++ b/jwala-services/src/test/resources/managerXml/vars.properties
@@ -30,7 +30,6 @@ remote.jwala.execution.timeout.seconds = 300
 jwala.apache.httpd.zip.name=apache-httpd-2.4.20.zip
 remote.paths.httpd.root.dir.name=c:/ctp
 
-remote.jwala.data.dir=c:/ctp/data
 jmap.dump.live.enabled=false
 
 tomcat.manager.xml.ssl.path=/conf/ssl/localhost

--- a/jwala-tomcat/src/main/resources/data/properties/vars.properties
+++ b/jwala-tomcat/src/main/resources/data/properties/vars.properties
@@ -15,8 +15,6 @@ ssh.encrypted.password=#REQUIRED#
 jwala.authorization=true
 jwala.role.admin=Jwala Administrator
 
-remote.jwala.data.dir=#REQUIRED#
-
 jmap.dump.live.enabled=false
 net.stop.sleep.time.seconds=120
 commands.scripts-path=../data/scripts

--- a/jwala-webservices/src/test/java/com/cerner/jwala/ws/rest/v1/service/group/impl/GroupServiceImplDeployTest.java
+++ b/jwala-webservices/src/test/java/com/cerner/jwala/ws/rest/v1/service/group/impl/GroupServiceImplDeployTest.java
@@ -41,7 +41,6 @@ import com.cerner.jwala.ws.rest.v1.service.jvm.JvmServiceRest;
 import com.cerner.jwala.ws.rest.v1.service.jvm.impl.JvmServiceRestImpl;
 import com.cerner.jwala.ws.rest.v1.service.webserver.WebServerServiceRest;
 import com.cerner.jwala.ws.rest.v1.service.webserver.impl.WebServerServiceRestImpl;
-import org.apache.commons.io.FileUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -58,7 +57,6 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.support.AnnotationConfigContextLoader;
 
 import javax.ws.rs.core.Response;
-import java.io.File;
 import java.io.IOException;
 import java.net.Inet4Address;
 import java.net.UnknownHostException;
@@ -90,7 +88,6 @@ public class GroupServiceImplDeployTest {
 
     private AuthenticatedUser mockAuthUser = mock(AuthenticatedUser.class);
     private User mockUser = mock(User.class);
-    private String httpdConfDirPath;
 
     public GroupServiceImplDeployTest() {
         System.setProperty(ApplicationProperties.PROPERTIES_ROOT_PATH, "./src/test/resources");
@@ -102,16 +99,10 @@ public class GroupServiceImplDeployTest {
         PowerMockito.mockStatic(JwalaUtils.class);
         PowerMockito.when(JwalaUtils.getHostAddress("TestHost")).thenReturn(Inet4Address.getLocalHost().getHostAddress());
         System.setProperty(ApplicationProperties.PROPERTIES_ROOT_PATH, "./src/test/resources");
-        httpdConfDirPath = ApplicationProperties.get("remote.jwala.data.dir") + "/httpd";
-        // assertTrue(new File(httpdConfDirPath).mkdirs());
-        new File(httpdConfDirPath).mkdirs();
-        // assertTrue(new File(generatedResourceDir).mkdirs());
-        new File(httpdConfDirPath).mkdirs();
     }
 
     @After
     public void tearDown() throws IOException {
-        FileUtils.deleteDirectory(new File(httpdConfDirPath));
         System.clearProperty(ApplicationProperties.PROPERTIES_ROOT_PATH);
     }
 


### PR DESCRIPTION
Instead of using a fixed directory where to put the heap dump, save it instead in the tomcat media's remote directory under [JVM name]/heap-dump

For details please refer to [SOARCOM-3079](https://jira2.cerner.com/browse/SOARCOM-3079)