### PR TITLE
Fix base filename extraction issue

### DIFF
--- a/jwala-services/src/main/java/com/cerner/jwala/service/media/impl/MediaServiceImpl.java
+++ b/jwala-services/src/main/java/com/cerner/jwala/service/media/impl/MediaServiceImpl.java
@@ -83,7 +83,7 @@ public class MediaServiceImpl implements MediaService {
 
         // filename can be the full path or just the name that is why we need to convert it to Paths
         // to extract the base name e.g. c:/jdk.zip -> jdk.zip or jdk.zip -> jdk.zip
-        final String filename = Paths.get((String) mediaFileDataMap.get("filename")).getFileName().toString();
+        final String filename = FilenameUtils.getName((String) mediaFileDataMap.get("filename"));
 
         try {
             mediaDao.findByNameAndType(media.getName(), media.getType());


### PR DESCRIPTION
The issues is that  in Linux, Jwala has "[drive]:\[pathName]\..." appended in its media's local path on media upload e.g. localPath = /opt/ctp/jwala-0.0.238/apache-tomcat-7.0.55/data/binaries/D:\jwala-ui-integ-test-support-files\media\apache-httpd-2.4.20-7ba00517-ecbf-4b40-bcec-19aa3db412ad.zip. This happens mostly in IE since it sends the fully qualified path of the file not just fhe file name. The root cause of the bug is that java.nio.file.Paths detects that it is invoked in Linux and considers "\" as part of the filename and not as a separator which is rightfully so.  That is why the issue is not seen in Jwala running in Windows.