### PR TITLE
Webapp resource updates from group

### DIFF
--- a/jwala-services/src/main/java/com/cerner/jwala/service/resource/impl/ResourceServiceImpl.java
+++ b/jwala-services/src/main/java/com/cerner/jwala/service/resource/impl/ResourceServiceImpl.java
@@ -995,7 +995,11 @@ public class ResourceServiceImpl implements ResourceService {
             }
         } else if (entity instanceof Application) {
             String templateContentApplication;
-            Application application = setApplicationWarDeployPath((Application) entity);
+            final Application entityApplication = (Application) entity;
+            Application application = setApplicationWarDeployPath(entityApplication);
+            if (entityApplication.getParentJvm() != null) {
+                application.setParentJvm(entityApplication.getParentJvm());
+            }
             if (application.getParentJvm() != null) {
                 templateContentApplication = applicationPersistenceService.getResourceTemplate(
                         application.getName(),

--- a/jwala-services/src/main/java/com/cerner/jwala/service/resource/impl/ResourceServiceImpl.java
+++ b/jwala-services/src/main/java/com/cerner/jwala/service/resource/impl/ResourceServiceImpl.java
@@ -1015,8 +1015,7 @@ public class ResourceServiceImpl implements ResourceService {
             }
         } else if (entity instanceof Application) {
             String templateContentApplication;
-            final Application entityApplication = (Application) entity;
-            Application application = setApplicationWarDeployPath(entityApplication);
+            Application application = setApplicationWarDeployPath((Application) entity);
             if (application.getParentJvm() != null) {
                 templateContentApplication = applicationPersistenceService.getResourceTemplate(
                         application.getName(),


### PR DESCRIPTION
- the application's parent JVM was getting lost when generating the resource template
- add the application's parent JVM back after generating the config
- also do some minor refactoring to improve readability and reusability