### PR TITLE
hotfix for the war not uploading correctly when using meta data

### DIFF
--- a/jwala-services/src/main/java/com/cerner/jwala/service/resource/impl/ResourceServiceImpl.java
+++ b/jwala-services/src/main/java/com/cerner/jwala/service/resource/impl/ResourceServiceImpl.java
@@ -604,7 +604,7 @@ public class ResourceServiceImpl implements ResourceService {
                     null,
                     applicationPersistenceService.getApplication(targetAppName),
                     ResourceGeneratorType.METADATA);
-            applicationPersistenceService.updateWarInfo(targetAppName, metaData.getTemplateName(), templateContent, tokenizedWarDeployPath);
+            applicationPersistenceService.updateWarInfo(targetAppName, metaData.getDeployFileName(), templateContent, tokenizedWarDeployPath);
         }
         final String deployFileName = metaData.getDeployFileName();
 

--- a/jwala-services/src/main/java/com/cerner/jwala/service/resource/impl/ResourceServiceImpl.java
+++ b/jwala-services/src/main/java/com/cerner/jwala/service/resource/impl/ResourceServiceImpl.java
@@ -597,7 +597,7 @@ public class ResourceServiceImpl implements ResourceService {
         ConfigTemplate createdConfigTemplate = null;
 
         if (MediaType.APPLICATION_ZIP.equals(metaData.getContentType()) &&
-                metaData.getTemplateName().toLowerCase(Locale.US).endsWith(WAR_FILE_EXTENSION)) {
+                metaData.getDeployFileName().toLowerCase(Locale.US).endsWith(WAR_FILE_EXTENSION)) {
             String tokenizedWarDeployPath = resourceContentGeneratorService.generateContent(
                     metaData.getDeployFileName(),
                     metaData.getDeployPath(),

--- a/jwala-services/src/test/java/com/cerner/jwala/service/resource/ResourceServiceImplTest.java
+++ b/jwala-services/src/test/java/com/cerner/jwala/service/resource/ResourceServiceImplTest.java
@@ -325,6 +325,35 @@ public class ResourceServiceImplTest {
     }
 
     @Test
+    public void testCreateGroupedAppsTemplateWar() {
+        final InputStream metaDataIn = this.getClass().getClassLoader()
+                .getResourceAsStream("resource-service-test-files/create-grouped-apps-template-test-metadata-for-war.json");
+        final InputStream templateIn = this.getClass().getClassLoader()
+                .getResourceAsStream("binaries/apache-tomcat-test.zip");
+
+        final List<Application> appList = new ArrayList<>();
+        final Application mockApp = mock(Application.class);
+        final Application mockApp2 = mock(Application.class);
+        when(mockApp.getName()).thenReturn("test-app-name");
+        when(mockApp2.getName()).thenReturn("test-app-name2");
+        appList.add(mockApp);
+        appList.add(mockApp2);
+        final Group mockGroup = mock(Group.class);
+        Set<Jvm> jvmSet = new HashSet<>();
+        Jvm mockJvm = mock(Jvm.class);
+        jvmSet.add(mockJvm);
+        when(mockGroup.getJvms()).thenReturn(jvmSet);
+        when(mockJvm.getJvmName()).thenReturn("test-jvm-name");
+        when(Config.mockAppPersistenceService.findApplicationsBelongingTo(eq("test-group"))).thenReturn(appList);
+        when(Config.mockGroupPesistenceService.getGroup(eq("test-group"))).thenReturn(mockGroup);
+        User mockUser = mock(User.class);
+        when(mockUser.getId()).thenReturn("user-id");
+        resourceService.createTemplate(metaDataIn, templateIn, "test-app-name", mockUser);
+        verify(Config.mockAppPersistenceService).updateWarInfo(eq("test-app-name"), eq("deploy-file-name.war"), eq("thePath"), eq("/deploy/path"));
+        verify(Config.mockGroupPesistenceService).populateGroupAppTemplate(anyString(), anyString(), anyString(), anyString(), anyString());
+    }
+
+    @Test
     public void testGenerateResourceFile() {
         File httpdTemplate = new File("../jwala-common/src/test/resources/HttpdConfTemplate.tpl");
         try {

--- a/jwala-services/src/test/resources/resource-service-test-files/create-grouped-apps-template-test-metadata-for-war.json
+++ b/jwala-services/src/test/resources/resource-service-test-files/create-grouped-apps-template-test-metadata-for-war.json
@@ -1,0 +1,13 @@
+{
+  "deployPath" : "/deploy/path",
+  "templateName" : "template-name.war",
+  "deployFileName" : "deploy-file-name.war",
+  "unpack" : false,
+  "contentType" : "application/zip",
+  "entity" : {
+    "type" : "GROUPED_APPS",
+    "group" : "test-group",
+    "target" : "test-webapp",
+    "deployToJvms" : false
+  }
+}

--- a/jwala-services/src/test/resources/resource-service-test-files/create-grouped-apps-template-test-metadata-for-war.json
+++ b/jwala-services/src/test/resources/resource-service-test-files/create-grouped-apps-template-test-metadata-for-war.json
@@ -1,6 +1,6 @@
 {
   "deployPath" : "/deploy/path",
-  "templateName" : "template-name.war",
+  "templateName" : "template-name.war.tpl",
   "deployFileName" : "deploy-file-name.war",
   "unpack" : false,
   "contentType" : "application/zip",


### PR DESCRIPTION
The problem: when uploading the war using the meta data file (deprecated method), the templateName attribute is being used to populate the war name. This can cause deploying the war to fail when the templateName and deployFileName are different in the meta data file.

The fix: use the deployFileName as the name of the war when uploading the war as a resource using the meta data (again, this has already been deprecated)