### PR TITLE
war not uploading correctly when using meta data

### DIFF
--- a/jwala-services/src/main/java/com/cerner/jwala/service/resource/impl/ResourceServiceImpl.java
+++ b/jwala-services/src/main/java/com/cerner/jwala/service/resource/impl/ResourceServiceImpl.java
@@ -596,14 +596,14 @@ public class ResourceServiceImpl implements ResourceService {
         ConfigTemplate createdConfigTemplate = null;
 
         if (MediaType.APPLICATION_ZIP.equals(metaData.getContentType()) &&
-                metaData.getTemplateName().toLowerCase(Locale.US).endsWith(WAR_FILE_EXTENSION)) {
+                metaData.getDeployFileName().toLowerCase(Locale.US).endsWith(WAR_FILE_EXTENSION)) {
             String tokenizedWarDeployPath = resourceContentGeneratorService.generateContent(
                     metaData.getDeployFileName(),
                     metaData.getDeployPath(),
                     null,
                     applicationPersistenceService.getApplication(targetAppName),
                     ResourceGeneratorType.METADATA);
-            applicationPersistenceService.updateWarInfo(targetAppName, metaData.getTemplateName(), templateContent, tokenizedWarDeployPath);
+            applicationPersistenceService.updateWarInfo(targetAppName, metaData.getDeployFileName(), templateContent, tokenizedWarDeployPath);
         }
         final String deployFileName = metaData.getDeployFileName();
 

--- a/jwala-services/src/test/resources/resource-service-test-files/create-grouped-apps-template-test-metadata-for-war.json
+++ b/jwala-services/src/test/resources/resource-service-test-files/create-grouped-apps-template-test-metadata-for-war.json
@@ -1,0 +1,13 @@
+{
+  "deployPath" : "/deploy/path",
+  "templateName" : "template-name.war.tpl",
+  "deployFileName" : "deploy-file-name.war",
+  "unpack" : false,
+  "contentType" : "application/zip",
+  "entity" : {
+    "type" : "GROUPED_APPS",
+    "group" : "test-group",
+    "target" : "test-webapp",
+    "deployToJvms" : false
+  }
+}


### PR DESCRIPTION
The problem: when uploading the war using the meta data file (deprecated method), the templateName attribute is being used to populate the war name. This can cause deploying the war to fail when the templateName and deployFileName are different in the meta data file.

The fix: use the deployFileName as the name of the war when uploading the war as a resource using the meta data (again, this has already been deprecated)