### PR TITLE
Added threaddump report saving functionality to Jwala

### DIFF
--- a/jwala-integration-test/src/test/java/com/cerner/jwala/ui/selenium/steps/operation/ThreadDumpRunSteps.java
+++ b/jwala-integration-test/src/test/java/com/cerner/jwala/ui/selenium/steps/operation/ThreadDumpRunSteps.java
@@ -5,6 +5,10 @@ import cucumber.api.java.en.Then;
 import cucumber.api.java.en.When;
 import org.openqa.selenium.By;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+
+import java.io.File;
+import java.util.Properties;
 
 /**
  * Created by Sharvari Barve on 7/18/2017.
@@ -12,12 +16,16 @@ import org.springframework.beans.factory.annotation.Autowired;
 public class ThreadDumpRunSteps {
 
     @Autowired
+    @Qualifier("parameterProperties")
+    private Properties paramProp;
+
+    @Autowired
     private JwalaUi jwalaUi;
 
     private String origWindowHandle;
 
     @When("^I click thread dump of jvm \"(.*)\" of the group \"(.*)\"$")
-    public void clickThreadDump(String jvmName, String groupName){
+    public void clickThreadDump(String jvmName, String groupName) {
         origWindowHandle = jwalaUi.getWebDriver().getWindowHandle();
         jwalaUi.clickWhenReady(By.xpath("//tr[td[text()='" + groupName + "']]/following-sibling::tr//td[text()='"
                 + jvmName + "']/following-sibling::td//button[@title='Thread Dump']"));
@@ -30,6 +38,17 @@ public class ThreadDumpRunSteps {
         if (origWindowHandle != null) {
             jwalaUi.getWebDriver().close();
             jwalaUi.getWebDriver().switchTo().window(origWindowHandle);
+        }
+    }
+
+    @Then("^I verify thread dump report file with path as \"(.*)\"$")
+    public void verifyThreadDumpReport(String path) {
+        //only the partial file name is checked due to timestamp and timelag while running the tests
+        String filenamePrefix = "thread_dump_";
+        File threadDumpPath = new File(paramProp.getProperty(path));
+        File[] threadDumpReports = threadDumpPath.listFiles();
+        for (int i = 0; i < threadDumpReports.length; i++) {
+            assert (threadDumpReports[i].getName().startsWith(filenamePrefix));
         }
     }
 }

--- a/jwala-integration-test/src/test/resources/com/cerner/jwala/ui/selenium/operations/controlJvm.feature
+++ b/jwala-integration-test/src/test/resources/com/cerner/jwala/ui/selenium/operations/controlJvm.feature
@@ -56,6 +56,7 @@ Scenario: Do a happy path start, thread dump, heap dump, stop and deletion of a 
     When I click thread dump of jvm "CONTROL-JVM-TEST-J" of the group "CONTROL-JVM-TEST-G"
     Then I don't see the click status tooltip
     And I see the thread dump page
+    And I verify thread dump report file with path as "thread.dump.path"
 
     # test heap dump
     When I click on heap dump of "CONTROL-JVM-TEST-J" jvm of "CONTROL-JVM-TEST-G" group

--- a/jwala-tomcat/src/main/resources/data/scripts/thread-dump.sh
+++ b/jwala-tomcat/src/main/resources/data/scripts/thread-dump.sh
@@ -8,12 +8,19 @@ esac
 export JAVA_HOME=$1
 export JVM_INSTANCE_DIR=$2
 export JVM_NAME=$3
+
+if [ ! -d ${JVM_INSTANCE_DIR}/thread_dump_reports} ]; then
+      mkdir -p ${JVM_INSTANCE_DIR}/thread_dump_reports
+fi
+
+current_time=$(date +"%m-%d-%Y-%T")
+
 if $linux; then
 	echo $(<${JVM_INSTANCE_DIR}/logs/catalina.pid)
-	/usr/bin/sudo -u tomcat ${JAVA_HOME}/bin/jstack $(<${JVM_INSTANCE_DIR}/logs/catalina.pid)
+	/usr/bin/sudo -u tomcat ${JAVA_HOME}/bin/jstack $(<${JVM_INSTANCE_DIR}/logs/catalina.pid) 2>&1 | tee  ${JVM_INSTANCE_DIR}/thread_dump_reports/thread_dump_$current_time
 fi
 
 if $cygwin; then
     export JVMPID=`sc queryex $JVM_NAME | /usr/bin/grep PID | /usr/bin/awk '{ print $3 }'`
-	${JAVA_HOME}/bin/jstack -l ${JVMPID}
+	${JAVA_HOME}/bin/jstack -l ${JVMPID} 2>&1 |tee ${JVM_INSTANCE_DIR}/thread_dump_reports/thread_dump_$current_time
 fi


### PR DESCRIPTION
The change to save report is made in the thread-dump shell script, by piping the output to the relevant file. Currently both browser and file functionalities for thread dump are there.