### PR TITLE
generate REST API documentation using Swagger

### DIFF
--- a/jwala-webservices/build.gradle
+++ b/jwala-webservices/build.gradle
@@ -61,7 +61,7 @@ apply plugin: 'com.benjaminsproule.swagger'
 swagger {
     apiSource {
         springmvc = false
-        locations = [ 'com.cerner.jwala.ws.rest.v1.service.admin' ]
+        locations = [ 'com.cerner.jwala.ws.rest.v1' ]
         schemes = [ 'https' ]
         host = 'localhost:8001'
         basePath = '/jwala/v1.0'

--- a/jwala-webservices/build.gradle
+++ b/jwala-webservices/build.gradle
@@ -66,7 +66,7 @@ swagger {
         host = 'localhost:8001'
         basePath = '/jwala/v1.0'
         info {
-            title = 'Jwala Tomcat Manager'
+            title = 'Jwala API documentation'
             version = 'v1.0'
         }
         securityDefinition {

--- a/jwala-webservices/build.gradle
+++ b/jwala-webservices/build.gradle
@@ -29,6 +29,8 @@ dependencies {
 	testRuntime group: 'org.apache.tomcat', name: 'tomcat-coyote', version: "$project.versions.tomcat"
 
     testCompile group: 'org.apache.tomcat', name: 'tomcat-catalina', version: "$project.versions.tomcat"
+
+    compile group: 'io.swagger', name: 'swagger-core', version: '1.5.17'
 }
 
 test {
@@ -40,5 +42,37 @@ test {
                     "*.configuration.*",
                     "**.configuration.**",
                     "com.cerner.jwala.service.configuration.service.*"]
+    }
+}
+
+
+/*** Gradle plugin for creating Swagger artifact ***/
+buildscript {
+    repositories {
+        jcenter()
+    }
+    dependencies {
+        classpath 'com.benjaminsproule:swagger-gradle-plugin:+'
+    }
+}
+
+apply plugin: 'com.benjaminsproule.swagger'
+
+swagger {
+    apiSource {
+        springmvc = false
+        locations = [ 'com.cerner.jwala.ws.rest.v1.service.admin' ]
+        schemes = [ 'https' ]
+        host = 'localhost:8001'
+        basePath = '/jwala/v1.0'
+        info {
+            title = 'Jwala Tomcat Manager'
+            version = 'v1.0'
+        }
+        securityDefinition {
+            name = 'basicAuth'
+            type = 'basic'
+        }
+        swaggerDirectory = "${project.rootProject.buildDir.path}/swagger-ui"
     }
 }

--- a/jwala-webservices/src/main/java/com/cerner/jwala/ws/rest/v1/service/HistoryServiceRest.java
+++ b/jwala-webservices/src/main/java/com/cerner/jwala/ws/rest/v1/service/HistoryServiceRest.java
@@ -1,5 +1,10 @@
 package com.cerner.jwala.ws.rest.v1.service;
 
+import com.cerner.jwala.persistence.jpa.domain.JpaHistory;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+
 import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
@@ -9,6 +14,7 @@ import javax.ws.rs.core.Response;
  *
  * Created by Jedd Cuison on 12/7/2015.
  */
+@Api(value = "/history", tags = "history")
 @Path("/history")
 @Produces(MediaType.APPLICATION_JSON)
 public interface HistoryServiceRest {
@@ -21,7 +27,11 @@ public interface HistoryServiceRest {
      */
     @GET
     @Path("/{groupName}")
-    Response findHistory(@PathParam("groupName") String groupName, @QueryParam("numOfRec") Integer numOfRec);
+    @ApiOperation(value = "Retrieve history data",
+            response = JpaHistory.class
+    )
+    Response findHistory(@ApiParam(value = "The name of the group to retrieve data", required = true) @PathParam("groupName") String groupName,
+                         @ApiParam(value = "The number of history records to retrieve", required = true) @QueryParam("numOfRec") Integer numOfRec);
 
     /**
      * Retrieve history data.
@@ -32,7 +42,11 @@ public interface HistoryServiceRest {
      */
     @GET
     @Path("/{groupName}/{serverName}")
-    Response findHistory(@PathParam("groupName") String groupName, @PathParam("serverName") String serverName,
-                         @QueryParam("numOfRec") Integer numOfRec);
+    @ApiOperation(value = "Retrieve history data for a specific host",
+            response = JpaHistory.class
+    )
+    Response findHistory(@ApiParam(value = "The name of the group to retrieve data", required = true) @PathParam("groupName") String groupName,
+                         @ApiParam(value = "The name of the host to retrieve data", required = true) @PathParam("serverName") String serverName,
+                         @ApiParam(value = "The number of history records to retrieve", required = true) @QueryParam("numOfRec") Integer numOfRec);
 
 }

--- a/jwala-webservices/src/main/java/com/cerner/jwala/ws/rest/v1/service/admin/AdminServiceRest.java
+++ b/jwala-webservices/src/main/java/com/cerner/jwala/ws/rest/v1/service/admin/AdminServiceRest.java
@@ -1,8 +1,6 @@
 package com.cerner.jwala.ws.rest.v1.service.admin;
 
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.*;
 import org.springframework.security.core.GrantedAuthority;
 
 import javax.servlet.ServletContext;
@@ -49,6 +47,7 @@ public interface AdminServiceRest {
     @ApiOperation(value = "Get the content of the MANIFEST.MF of the Jwala application",
             response = Attributes.class
     )
+    @ApiResponses(value = { @ApiResponse(code = 500, message = "Failed to read MANIFEST.MF")})
     Response manifest(@Context ServletContext context);
 
     @GET

--- a/jwala-webservices/src/main/java/com/cerner/jwala/ws/rest/v1/service/admin/AdminServiceRest.java
+++ b/jwala-webservices/src/main/java/com/cerner/jwala/ws/rest/v1/service/admin/AdminServiceRest.java
@@ -1,17 +1,28 @@
 package com.cerner.jwala.ws.rest.v1.service.admin;
 
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+
 import javax.servlet.ServletContext;
-import javax.ws.rs.*;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
+@Api(value = "/admin", tags = "admin")
 @Path("/admin")
 @Produces(MediaType.APPLICATION_JSON)
 public interface AdminServiceRest {
 
     @GET
     @Path("/properties/reload")
+    @ApiOperation(value = "Reload the application properties",
+            notes = "Some properties only reload on application restart",
+            response = Response.class
+    )
     Response reload();
 
     @GET

--- a/jwala-webservices/src/main/java/com/cerner/jwala/ws/rest/v1/service/admin/AdminServiceRest.java
+++ b/jwala-webservices/src/main/java/com/cerner/jwala/ws/rest/v1/service/admin/AdminServiceRest.java
@@ -2,6 +2,8 @@ package com.cerner.jwala.ws.rest.v1.service.admin;
 
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import org.springframework.security.core.GrantedAuthority;
 
 import javax.servlet.ServletContext;
 import javax.ws.rs.GET;
@@ -11,6 +13,8 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import java.util.Map;
+import java.util.jar.Attributes;
 
 @Api(value = "/admin", tags = "admin")
 @Path("/admin")
@@ -19,29 +23,47 @@ public interface AdminServiceRest {
 
     @GET
     @Path("/properties/reload")
-    @ApiOperation(value = "Reload the application properties",
+    @ApiOperation(value = "Reload the Jwala application properties",
             notes = "Some properties only reload on application restart",
-            response = Response.class
+            response = Map.class
     )
     Response reload();
 
     @GET
     @Path("/properties/view")
+    @ApiOperation(value = "Get the Jwala application properties",
+            notes = "Return type is a JSON object",
+            response = Map.class
+    )
     Response view();
 
     @POST
     @Path("/properties/encrypt")
-    Response encrypt(String cleartext);
+    @ApiOperation(value = "Encrypt a clear text phrase using the encryptExpression defined in the Jwala application properties",
+            response = String.class
+    )
+    Response encrypt(@ApiParam(value = "The string to decrypt", required = true) String cleartext);
 
     @GET
     @Path("/manifest")
+    @ApiOperation(value = "Get the content of the MANIFEST.MF of the Jwala application",
+            response = Attributes.class
+    )
     Response manifest(@Context ServletContext context);
 
     @GET
     @Path("/auth/state")
+    @ApiOperation(value = "Get the value if the jwala.authorization property",
+            notes = "If true, then some functions are disabled for users not in the jwala.role.admin group; if false then all functionality is available to all users",
+            response = String.class
+    )
     Response isJwalaAuthorizationEnabled();
 
     @GET
     @Path("/context/authorization")
+    @ApiOperation(value = "Get the authorization details",
+            notes = "Returns the details of the authorization configuration",
+            response = GrantedAuthority.class
+    )
     Response getAuthorizationDetails();
 }

--- a/jwala-webservices/src/main/java/com/cerner/jwala/ws/rest/v1/service/app/ApplicationServiceRest.java
+++ b/jwala-webservices/src/main/java/com/cerner/jwala/ws/rest/v1/service/app/ApplicationServiceRest.java
@@ -8,6 +8,8 @@ import com.cerner.jwala.service.exception.ApplicationServiceException;
 import com.cerner.jwala.ws.rest.v1.provider.AuthenticatedUser;
 import com.cerner.jwala.ws.rest.v1.service.app.impl.JsonCreateApplication;
 import com.cerner.jwala.ws.rest.v1.service.app.impl.JsonUpdateApplication;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
 
 import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
@@ -18,10 +20,16 @@ import javax.ws.rs.core.Response;
 public interface ApplicationServiceRest {
 
     @GET
-    Response getApplications(@QueryParam("group.id") final Identifier<Group> aGroupId);
+    @ApiOperation(value = "Get the data for all of the applications configured for a group",
+            response = Application.class
+    )
+    Response getApplications(@ApiParam(value = "The group ID to query", required = true) @QueryParam("group.id") final Identifier<Group> aGroupId);
 
     @GET
     @Path("/{applicationId}")
+    @ApiOperation(value = "Get the data for all of the applications configured for a group",
+            response = Application.class
+    )
     Response getApplication(@PathParam("applicationId") final Identifier<Application> anAppId);
 
     @GET

--- a/jwala-webservices/src/main/java/com/cerner/jwala/ws/rest/v1/service/app/ApplicationServiceRest.java
+++ b/jwala-webservices/src/main/java/com/cerner/jwala/ws/rest/v1/service/app/ApplicationServiceRest.java
@@ -54,7 +54,7 @@ public interface ApplicationServiceRest {
     )
     @ApiResponses(@ApiResponse(code = 500, message = "An application already exists with the provided name"))
     Response createApplication(@ApiParam(value = "The application configuration to use", required = true) final JsonCreateApplication anAppToCreate,
-                               @BeanParam final AuthenticatedUser aUser);
+                               @ApiParam(value = "The authentication details of user") @BeanParam final AuthenticatedUser aUser);
 
     @PUT
     @Consumes(MediaType.APPLICATION_JSON)
@@ -63,7 +63,7 @@ public interface ApplicationServiceRest {
     )
     @ApiResponses(@ApiResponse(code = 500, message = "The application update failed"))
     Response updateApplication(@ApiParam(value = "The updated application configuration to use", required = true) final JsonUpdateApplication appsToUpdate,
-                               @BeanParam final AuthenticatedUser aUser) throws ApplicationServiceException;
+                               @ApiParam(value = "The authentication details of user") @BeanParam final AuthenticatedUser aUser) throws ApplicationServiceException;
 
     @DELETE
     @Path("/{applicationId}")
@@ -71,7 +71,7 @@ public interface ApplicationServiceRest {
             response = Response.class
     )
     Response removeApplication(@ApiParam(value = "The application ID to query", required = true) @PathParam("applicationId") final Identifier<Application> anAppToRemove,
-                               @BeanParam final AuthenticatedUser aUser);
+                               @ApiParam(value = "The authentication details of user") @BeanParam final AuthenticatedUser aUser);
 
     @PUT
     @Path("/{applicationId}/war/deploy")
@@ -80,7 +80,7 @@ public interface ApplicationServiceRest {
             response = Application.class
     )
     Response deployWebArchive(@ApiParam(value = "The application ID to query", required = true) @PathParam("applicationId") final Identifier<Application> anAppToGet,
-                              @BeanParam final AuthenticatedUser aUser);
+                              @ApiParam(value = "The authentication details of user") @BeanParam final AuthenticatedUser aUser);
 
     @PUT
     @Path("/{applicationId}/war/deploy/{hostName}")
@@ -121,7 +121,7 @@ public interface ApplicationServiceRest {
                         @ApiParam(value = "The group name to query", required = true) @MatrixParam("groupName") String groupName,
                         @ApiParam(value = "The JVM name to query", required = true) @MatrixParam("jvmName") String jvmName,
                         @ApiParam(value = "The resource template name to query", required = true) @PathParam("resourceTemplateName") String resourceTemplateName,
-                        @BeanParam AuthenticatedUser aUser);
+                        @ApiParam(value = "The authentication details of user") @BeanParam AuthenticatedUser aUser);
 
     @PUT
     @Path("/{appName}/resources/preview/{resourceTemplateName}")
@@ -143,7 +143,7 @@ public interface ApplicationServiceRest {
             response = String.class
     )
     Response deployConf(@ApiParam(value = "The application name to query", required = true) @PathParam("appName") String appName,
-                        @BeanParam AuthenticatedUser aUser,
+                        @ApiParam(value = "The authentication details of user") @BeanParam AuthenticatedUser aUser,
                         @ApiParam(value = "The hostname of the target node") @QueryParam("hostName") String hostName);
 
     @GET
@@ -152,7 +152,7 @@ public interface ApplicationServiceRest {
             response = CommandOutput.class
     )
     Response checkIfFileExists(@ApiParam(value = "The absolute path of the file to check", required = true) @QueryParam("filePath") String filePath,
-                               @BeanParam AuthenticatedUser aUser,
+                               @ApiParam(value = "The authentication details of user") @BeanParam AuthenticatedUser aUser,
                                @ApiParam(value = "The name of the host where the file exists", required = true) @QueryParam("hostName") String hostName);
 
 }

--- a/jwala-webservices/src/main/java/com/cerner/jwala/ws/rest/v1/service/app/ApplicationServiceRest.java
+++ b/jwala-webservices/src/main/java/com/cerner/jwala/ws/rest/v1/service/app/ApplicationServiceRest.java
@@ -4,17 +4,18 @@ import com.cerner.jwala.common.domain.model.app.Application;
 import com.cerner.jwala.common.domain.model.group.Group;
 import com.cerner.jwala.common.domain.model.id.Identifier;
 import com.cerner.jwala.common.domain.model.jvm.Jvm;
+import com.cerner.jwala.common.exec.CommandOutput;
 import com.cerner.jwala.service.exception.ApplicationServiceException;
 import com.cerner.jwala.ws.rest.v1.provider.AuthenticatedUser;
 import com.cerner.jwala.ws.rest.v1.service.app.impl.JsonCreateApplication;
 import com.cerner.jwala.ws.rest.v1.service.app.impl.JsonUpdateApplication;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.*;
 
 import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
+@Api(value = "/applications", tags = "applications")
 @Path("/applications")
 @Produces(MediaType.APPLICATION_JSON)
 public interface ApplicationServiceRest {
@@ -27,80 +28,130 @@ public interface ApplicationServiceRest {
 
     @GET
     @Path("/{applicationId}")
-    @ApiOperation(value = "Get the data for all of the applications configured for a group",
+    @ApiOperation(value = "Get the data for a specific application by the application ID",
             response = Application.class
     )
-    Response getApplication(@PathParam("applicationId") final Identifier<Application> anAppId);
+    Response getApplication(@ApiParam(value = "The application ID to query", required = true) @PathParam("applicationId") final Identifier<Application> anAppId);
 
     @GET
     @Path("/application")
-    Response getApplicationByName(@MatrixParam("name") String name);
+    @ApiOperation(value = "Get the data for a specific application by the application name",
+            response = Application.class
+    )
+    Response getApplicationByName(@ApiParam(value = "The application name to query", required = true) @MatrixParam("name") String name);
 
     @GET
     @Path("/jvm/{jvmId}")
-    Response findApplicationsByJvmId(@PathParam("jvmId") final Identifier<Jvm> aJvmId);
+    @ApiOperation(value = "Get the data for all applications associated with a JVM by ID",
+            response = Application.class
+    )
+    Response findApplicationsByJvmId(@ApiParam(value = "The JVM ID to query", required = true) @PathParam("jvmId") final Identifier<Jvm> aJvmId);
 
     @POST
     @Consumes(MediaType.APPLICATION_JSON)
-    Response createApplication(final JsonCreateApplication anAppToCreate,
+    @ApiOperation(value = "Create a new application",
+            response = Application.class
+    )
+    @ApiResponses(@ApiResponse(code = 500, message = "An application already exists with the provided name"))
+    Response createApplication(@ApiParam(value = "The application configuration to use", required = true) final JsonCreateApplication anAppToCreate,
                                @BeanParam final AuthenticatedUser aUser);
 
     @PUT
     @Consumes(MediaType.APPLICATION_JSON)
-    Response updateApplication(final JsonUpdateApplication appsToUpdate,
+    @ApiOperation(value = "Update an existing application",
+            response = Application.class
+    )
+    Response updateApplication(@ApiParam(value = "The updated application configuration to use", required = true) final JsonUpdateApplication appsToUpdate,
                                @BeanParam final AuthenticatedUser aUser) throws ApplicationServiceException;
 
     @DELETE
     @Path("/{applicationId}")
-    Response removeApplication(@PathParam("applicationId") final Identifier<Application> anAppToRemove,
+    @ApiOperation(value = "Delete an existing application by ID",
+            response = Response.class
+    )
+    Response removeApplication(@ApiParam(value = "The application ID to query", required = true) @PathParam("applicationId") final Identifier<Application> anAppToRemove,
                                @BeanParam final AuthenticatedUser aUser);
 
     @PUT
     @Path("/{applicationId}/war/deploy")
-    Response deployWebArchive(@PathParam("applicationId") final Identifier<Application> anAppToGet,
+    @ApiOperation(value = "Deploy the war associated with the application",
+            notes = "The application is deployed to all the hosts configured for the group",
+            response = Application.class
+    )
+    Response deployWebArchive(@ApiParam(value = "The application ID to query", required = true) @PathParam("applicationId") final Identifier<Application> anAppToGet,
                               @BeanParam final AuthenticatedUser aUser);
-    
+
     @PUT
     @Path("/{applicationId}/war/deploy/{hostName}")
-    Response deployWebArchive(@PathParam("applicationId") final Identifier<Application> anAppToGet,
-    						  @PathParam("hostName") String hostName);
+    @ApiOperation(value = "Deploy the war associated with the application to a specific host",
+            notes = "The application is deployed only to the host specified",
+            response = Application.class
+    )
+    Response deployWebArchive(@ApiParam(value = "The application ID to query", required = true) @PathParam("applicationId") final Identifier<Application> anAppToGet,
+                              @ApiParam(value = "The hostname where the application will be deployed", required = true) @PathParam("hostName") String hostName);
 
     @GET
     @Path("/{jvmName}/{appName}/resources/name")
-    Response getResourceNames(@PathParam("appName") String appName, @PathParam("jvmName") String jvmName);
+    @ApiOperation(value = "Get the resources and template names associated with the application and JVM",
+            response = String.class
+    )
+    Response getResourceNames(@ApiParam(value = "The application name to query", required = true) @PathParam("appName") String appName,
+                              @ApiParam(value = "The JVM name to query", required = true) @PathParam("jvmName") String jvmName);
 
     @PUT
     @Path("/{appName}/resources/template/{resourceTemplateName}")
     @Consumes(MediaType.TEXT_PLAIN)
-    Response updateResourceTemplate(@PathParam("appName") final String appName,
-                                    @PathParam("resourceTemplateName") final String resourceTemplateName,
-                                    @MatrixParam("jvmName") final String jvmName,
-                                    @MatrixParam("groupName") final String groupName,
-                                    final String content);
+    @ApiOperation(value = "Update the resource template for the application",
+            response = String.class
+    )
+    @ApiResponses (@ApiResponse(code = 500, message = "Failed to update the resource template"))
+    Response updateResourceTemplate(@ApiParam(value = "The application name to query", required = true) @PathParam("appName") final String appName,
+                                    @ApiParam(value = "The name of the resource template to update", required = true) @PathParam("resourceTemplateName") final String resourceTemplateName,
+                                    @ApiParam(value = "The JVM name to query", required = true) @MatrixParam("jvmName") final String jvmName,
+                                    @ApiParam(value = "The group name to query", required = true) @MatrixParam("groupName") final String groupName,
+                                    @ApiParam(value = "The new content of the resource template", required = true) final String content);
 
     @PUT
     @Path("/{appName}/conf/{resourceTemplateName}")
-    Response deployConf(@PathParam("appName") String appName,
-                        @MatrixParam("groupName") String groupName,
-                        @MatrixParam("jvmName") String jvmName,
-                        @PathParam("resourceTemplateName") String resourceTemplateName,
+    @ApiOperation(value = "Deploy a specific application resource",
+            response = CommandOutput.class
+    )
+    Response deployConf(@ApiParam(value = "The application name to query", required = true) @PathParam("appName") String appName,
+                        @ApiParam(value = "The group name to query", required = true) @MatrixParam("groupName") String groupName,
+                        @ApiParam(value = "The JVM name to query", required = true) @MatrixParam("jvmName") String jvmName,
+                        @ApiParam(value = "The resource template name to query", required = true) @PathParam("resourceTemplateName") String resourceTemplateName,
                         @BeanParam AuthenticatedUser aUser);
 
     @PUT
     @Path("/{appName}/resources/preview/{resourceTemplateName}")
     @Consumes(MediaType.TEXT_PLAIN)
-    Response previewResourceTemplate(@PathParam("appName") String appName,
-                                     @MatrixParam("groupName") String groupName,
-                                     @MatrixParam("jvmName") String jvmName,
-                                     @PathParam("resourceTemplateName") String resourceTemplateName,
-                                     String template);
+    @ApiOperation(value = "Get the template content after running it through the template engine",
+            response = String.class
+    )
+    @ApiResponses (@ApiResponse(code = 500, message = "Error previewing template"))
+    Response previewResourceTemplate(@ApiParam(value = "The application name to query", required = true) @PathParam("appName") String appName,
+                                     @ApiParam(value = "The group name to query", required = true) @MatrixParam("groupName") String groupName,
+                                     @ApiParam(value = "The JVM name to query", required = true) @MatrixParam("jvmName") String jvmName,
+                                     @ApiParam(value = "The resource template name to query", required = true) @PathParam("resourceTemplateName") String resourceTemplateName,
+                                     @ApiParam(value = "The template content to generate", required = true) String template);
 
     @PUT
     @Path("/{appName}/conf")
-    Response deployConf(@PathParam("appName") String appName, @BeanParam AuthenticatedUser aUser, @QueryParam("hostName") String hostName);
+    @ApiOperation(value = "Deploy all of the application resources",
+            notes = "Does not deploy any resources associated to a JVM and application",
+            response = String.class
+    )
+    Response deployConf(@ApiParam(value = "The application name to query", required = true) @PathParam("appName") String appName,
+                        @BeanParam AuthenticatedUser aUser,
+                        @ApiParam(value = "The hostname of the target node") @QueryParam("hostName") String hostName);
 
     @GET
     @Path("/fileExists")
-    Response checkIfFileExists(@QueryParam("filePath") String filePath, @BeanParam AuthenticatedUser aUser, @QueryParam("hostName") String hostName);
+    @ApiOperation(value = "Check if a file exists on a node",
+            response = CommandOutput.class
+    )
+    Response checkIfFileExists(@ApiParam(value = "The absolute path of the file to check", required = true) @QueryParam("filePath") String filePath,
+                               @BeanParam AuthenticatedUser aUser,
+                               @ApiParam(value = "The name of the host where the file exists", required = true) @QueryParam("hostName") String hostName);
 
 }

--- a/jwala-webservices/src/main/java/com/cerner/jwala/ws/rest/v1/service/app/ApplicationServiceRest.java
+++ b/jwala-webservices/src/main/java/com/cerner/jwala/ws/rest/v1/service/app/ApplicationServiceRest.java
@@ -61,6 +61,7 @@ public interface ApplicationServiceRest {
     @ApiOperation(value = "Update an existing application",
             response = Application.class
     )
+    @ApiResponses(@ApiResponse(code = 500, message = "The application update failed"))
     Response updateApplication(@ApiParam(value = "The updated application configuration to use", required = true) final JsonUpdateApplication appsToUpdate,
                                @BeanParam final AuthenticatedUser aUser) throws ApplicationServiceException;
 

--- a/jwala-webservices/src/main/java/com/cerner/jwala/ws/rest/v1/service/balancermanager/BalancerManagerServiceRest.java
+++ b/jwala-webservices/src/main/java/com/cerner/jwala/ws/rest/v1/service/balancermanager/BalancerManagerServiceRest.java
@@ -1,38 +1,62 @@
 package com.cerner.jwala.ws.rest.v1.service.balancermanager;
 
+import com.cerner.jwala.common.domain.model.balancermanager.BalancerManagerState;
 import com.cerner.jwala.ws.rest.v1.provider.AuthUser;
-import org.springframework.beans.factory.InitializingBean;
+import io.swagger.annotations.*;
 
 import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
+@Api(value = "/balancermanager", tags = "balancermanager")
 @Path("/balancermanager")
 @Produces(MediaType.APPLICATION_JSON)
 public interface BalancerManagerServiceRest {
 
     @POST
     @Path("/{groupName}")
-    Response drainUserGroup(@PathParam("groupName") String groupName, String webServerNames,
+    @ApiOperation(value = "Drain the Web Servers in the group",
+            notes = "A list of web server names can be used to filter the web servers in the group (optional)",
+            response = BalancerManagerState.class
+    )
+    @ApiResponses(@ApiResponse(code = 500, message = "Failed to drain the web servers"))
+    Response drainUserGroup(@ApiParam(value = "The name of the group to drain all the web servers", required = true) @PathParam("groupName") String groupName,
+                            @ApiParam(value = "The name of the the web servers to drain") String webServerNames,
                             @BeanParam final AuthUser authUser);
 
     @POST
     @Path("/{groupName}/{webServerName}")
-    Response drainUserWebServer(@PathParam("groupName") String groupName, @PathParam("webServerName") String webServerName,
+    @ApiOperation(value = "Drain a single web server in a group",
+            response = BalancerManagerState.class
+    )
+    @ApiResponses(@ApiResponse(code = 500, message = "Drain web server error"))
+    Response drainUserWebServer(@ApiParam(value = "The name of the group to drain the web server", required = true) @PathParam("groupName") String groupName,
+                                @ApiParam(value = "The name of the web server to drain", required = true) @PathParam("webServerName") String webServerName,
                                 String jvmNames, @BeanParam AuthUser authUser);
 
     @POST
     @Path("/jvm/{jvmName}")
-    Response drainUserJvm(@PathParam("jvmName") String jvmName, @BeanParam AuthUser authUser);
+    @ApiOperation(value = "Drain a single JVM",
+            response = BalancerManagerState.class
+    )
+    Response drainUserJvm(@ApiParam(value = "The name of the JVM to drain", required = true) @PathParam("jvmName") String jvmName, @BeanParam AuthUser authUser);
 
     @POST
     @Path("/jvm/{groupName}/{jvmName}")
-    Response drainUserGroupJvm(@PathParam("groupName") String groupName, @PathParam("jvmName") String jvmName,
+    @ApiOperation(value = "Drain a single JVM in a specific group",
+            response = BalancerManagerState.class
+    )
+    @ApiResponses(@ApiResponse(code = 500, message = "Drain JVM error"))
+    Response drainUserGroupJvm(@ApiParam(value = "The JVM's group name", required = true) @PathParam("groupName") String groupName,
+                               @ApiParam(value = "The name of the JVM to drain", required = true) @PathParam("jvmName") String jvmName,
                                @BeanParam AuthUser authUser);
 
     @GET
     @Path("/{groupName}")
     // TODO: The path should be /{groupName}/drainStatus
-    Response getGroupDrainStatus(@PathParam("groupName") String groupName, @BeanParam AuthUser authUser);
+    @ApiOperation(value = "Get the status of any drained web servers and JVMs belonging to the group",
+            response = BalancerManagerState.class
+    )
+    Response getGroupDrainStatus(@ApiParam(value = "The name of the group to query for the status", required = true) @PathParam("groupName") String groupName, @BeanParam AuthUser authUser);
 
 }

--- a/jwala-webservices/src/main/java/com/cerner/jwala/ws/rest/v1/service/balancermanager/BalancerManagerServiceRest.java
+++ b/jwala-webservices/src/main/java/com/cerner/jwala/ws/rest/v1/service/balancermanager/BalancerManagerServiceRest.java
@@ -22,7 +22,7 @@ public interface BalancerManagerServiceRest {
     @ApiResponses(@ApiResponse(code = 500, message = "Failed to drain the web servers"))
     Response drainUserGroup(@ApiParam(value = "The name of the group to drain all the web servers", required = true) @PathParam("groupName") String groupName,
                             @ApiParam(value = "The name of the the web servers to drain") String webServerNames,
-                            @BeanParam final AuthUser authUser);
+                            @ApiParam(value = "The authentication details of user") @BeanParam final AuthUser authUser);
 
     @POST
     @Path("/{groupName}/{webServerName}")
@@ -32,14 +32,14 @@ public interface BalancerManagerServiceRest {
     @ApiResponses(@ApiResponse(code = 500, message = "Drain web server error"))
     Response drainUserWebServer(@ApiParam(value = "The name of the group to drain the web server", required = true) @PathParam("groupName") String groupName,
                                 @ApiParam(value = "The name of the web server to drain", required = true) @PathParam("webServerName") String webServerName,
-                                String jvmNames, @BeanParam AuthUser authUser);
+                                String jvmNames, @ApiParam(value = "The authentication details of user") @BeanParam AuthUser authUser);
 
     @POST
     @Path("/jvm/{jvmName}")
     @ApiOperation(value = "Drain a single JVM",
             response = BalancerManagerState.class
     )
-    Response drainUserJvm(@ApiParam(value = "The name of the JVM to drain", required = true) @PathParam("jvmName") String jvmName, @BeanParam AuthUser authUser);
+    Response drainUserJvm(@ApiParam(value = "The name of the JVM to drain", required = true) @PathParam("jvmName") String jvmName, @ApiParam(value = "The authentication details of user") @BeanParam AuthUser authUser);
 
     @POST
     @Path("/jvm/{groupName}/{jvmName}")
@@ -49,7 +49,7 @@ public interface BalancerManagerServiceRest {
     @ApiResponses(@ApiResponse(code = 500, message = "Drain JVM error"))
     Response drainUserGroupJvm(@ApiParam(value = "The JVM's group name", required = true) @PathParam("groupName") String groupName,
                                @ApiParam(value = "The name of the JVM to drain", required = true) @PathParam("jvmName") String jvmName,
-                               @BeanParam AuthUser authUser);
+                               @ApiParam(value = "The authentication details of user") @BeanParam AuthUser authUser);
 
     @GET
     @Path("/{groupName}")
@@ -57,6 +57,6 @@ public interface BalancerManagerServiceRest {
     @ApiOperation(value = "Get the status of any drained web servers and JVMs belonging to the group",
             response = BalancerManagerState.class
     )
-    Response getGroupDrainStatus(@ApiParam(value = "The name of the group to query for the status", required = true) @PathParam("groupName") String groupName, @BeanParam AuthUser authUser);
+    Response getGroupDrainStatus(@ApiParam(value = "The name of the group to query for the status", required = true) @PathParam("groupName") String groupName, @ApiParam(value = "The authentication details of user") @BeanParam AuthUser authUser);
 
 }

--- a/jwala-webservices/src/main/java/com/cerner/jwala/ws/rest/v1/service/balancermanager/BalancerManagerServiceRest.java
+++ b/jwala-webservices/src/main/java/com/cerner/jwala/ws/rest/v1/service/balancermanager/BalancerManagerServiceRest.java
@@ -32,7 +32,7 @@ public interface BalancerManagerServiceRest {
     @ApiResponses(@ApiResponse(code = 500, message = "Drain web server error"))
     Response drainUserWebServer(@ApiParam(value = "The name of the group to drain the web server", required = true) @PathParam("groupName") String groupName,
                                 @ApiParam(value = "The name of the web server to drain", required = true) @PathParam("webServerName") String webServerName,
-                                String jvmNames, @ApiParam(value = "The authentication details of user") @BeanParam AuthUser authUser);
+                                @ApiParam(value = "The list of JVM's") String jvmNames, @ApiParam(value = "The authentication details of user") @BeanParam AuthUser authUser);
 
     @POST
     @Path("/jvm/{jvmName}")

--- a/jwala-webservices/src/main/java/com/cerner/jwala/ws/rest/v1/service/group/GroupServiceRest.java
+++ b/jwala-webservices/src/main/java/com/cerner/jwala/ws/rest/v1/service/group/GroupServiceRest.java
@@ -32,7 +32,7 @@ public interface GroupServiceRest {
             response = Group.class
     )
     Response getGroups(@BeanParam final NameSearchParameterProvider aGroupNameSearch,
-                       @ApiParam(value = "The boolean value to fetch webservers data", required = true) @QueryParam("webServers") final boolean fetchWebServers);
+                       @ApiParam(value = "The boolean value to fetch web servers data", required = true) @QueryParam("webServers") final boolean fetchWebServers);
 
     @GET
     @Path("/{groupIdOrName}")
@@ -153,7 +153,7 @@ public interface GroupServiceRest {
      ****************************/
     @PUT
     @Path("/{groupName}/webservers/conf/{resourceFileName}")
-    @ApiOperation(value = "Generate and deploy group webservers file",
+    @ApiOperation(value = "Generate and deploy group web servers file",
             response = String.class
     )
     Response generateAndDeployGroupWebServersFile(@ApiParam(value = "The group name to query") @PathParam("groupName") final String groupName,
@@ -162,14 +162,14 @@ public interface GroupServiceRest {
 
     @GET
     @Path("/{groupName}/webservers/resources/name")
-    @ApiOperation(value = "Get group webserver resource names",
+    @ApiOperation(value = "Get group web server resource names",
             response = List.class
     )
     Response getGroupWebServersResourceNames(@ApiParam(value = "The group name to query") @PathParam("groupName") final String groupName);
 
     @GET
     @Path("/{groupName}/webservers/resources/template/{resourceTemplateName}")
-    @ApiOperation(value = "Get group webserver resource template",
+    @ApiOperation(value = "Get group web server resource template",
             response = String.class
     )
     Response getGroupWebServerResourceTemplate(@ApiParam(value = "The group name to query") @PathParam("groupName") final String groupName,
@@ -179,25 +179,25 @@ public interface GroupServiceRest {
     @PUT
     @Path("/{groupName}/webservers/resources/preview/{resourceTemplateName}")
     @Consumes(MediaType.TEXT_PLAIN)
-    @ApiOperation(value = "Preview group webserver resource template",
+    @ApiOperation(value = "Preview group web server resource template",
             response = String.class
     )
-    @ApiResponses(@ApiResponse(code = 500, message = "Failed to preview group Webserver resource template"))
+    @ApiResponses(@ApiResponse(code = 500, message = "Failed to preview group web server resource template"))
     Response previewGroupWebServerResourceTemplate(@ApiParam(value = "The group name to query") @PathParam("groupName") String groupName,
                                                    @ApiParam(value = "The resource template name") @PathParam("resourceTemplateName") final String resourceTemplateName,
-                                                   @ApiParam(value = "The webserver resource resource template") String template);
+                                                   @ApiParam(value = "The web server resource resource template") String template);
 
 
     @PUT
     @Path("/{groupName}/webservers/resources/template/{resourceTemplateName}")
     @Consumes(MediaType.TEXT_PLAIN)
-    @ApiOperation(value = "Update group webserver resource template",
+    @ApiOperation(value = "Update group web server resource template",
             response = String.class
     )
-    @ApiResponses(@ApiResponse(code = 500, message = "Failed to update group Webserver resource template"))
+    @ApiResponses(@ApiResponse(code = 500, message = "Failed to update group web server resource template"))
     Response updateGroupWebServerResourceTemplate(@ApiParam(value = "The group name to query") @PathParam("groupName") final String groupName,
                                                   @ApiParam(value = "The resource template name") @PathParam("resourceTemplateName") final String resourceTemplateName,
-                                                  @ApiParam(value = "The updated webserver resource template content") final String content);
+                                                  @ApiParam(value = "The updated web server resource template content") final String content);
 
     /********************
      * ** App Template ***
@@ -282,20 +282,20 @@ public interface GroupServiceRest {
 
     @POST
     @Path("/{groupId}/webservers/commands")
-    @ApiOperation(value = "Start all the webservers of a group",
+    @ApiOperation(value = "Start all the web servers of a group",
             response = CommandOutput.class
     )
     Response controlGroupWebservers(@ApiParam(value = "The group ID to query") @PathParam("groupId") final Identifier<Group> aGroupId,
-                                    @ApiParam(value = "The control group operation to start or stop all webservers") final JsonControlWebServer jsonControlWebServer,
+                                    @ApiParam(value = "The control group operation to start or stop all web servers") final JsonControlWebServer jsonControlWebServer,
                                     @BeanParam final AuthenticatedUser aUser);
 
 
     @POST
     @Path("/{groupId}/webservers/conf/deploy")
-    @ApiOperation(value = "Generate group webservers",
+    @ApiOperation(value = "Generate group web servers",
             response = Group.class
     )
-    @ApiResponses(@ApiResponse(code = 500, message = "Failed to generate group webservers"))
+    @ApiResponses(@ApiResponse(code = 500, message = "Failed to generate group web servers"))
     Response generateGroupWebservers(@ApiParam(value = "The group ID to query") @PathParam("groupId") final Identifier<Group> aGroupId,
                                      @BeanParam final AuthenticatedUser aUser);
 
@@ -326,42 +326,42 @@ public interface GroupServiceRest {
 
     @GET
     @Path("/children/startedCount")
-    @ApiOperation(value = "Get number of started webservers and JVMs count",
+    @ApiOperation(value = "Get number of started web servers and JVMs count",
             response = Long.class
     )
     Response getStartedWebServersAndJvmsCount();
 
     @GET
     @Path("/children/startedAndStoppedCount")
-    @ApiOperation(value = "Get number of started and stopped webservers, JVMs count",
+    @ApiOperation(value = "Get number of started and stopped web servers, JVMs count",
             response = Long.class
     )
     Response getStartedAndStoppedWebServersAndJvmsCount();
 
     @GET
     @Path("/{groupName}/children/startedCount")
-    @ApiOperation(value = "Get number of started webservers and JVMs count of a group",
+    @ApiOperation(value = "Get number of started web servers and JVMs count of a group",
             response = Long.class
     )
     Response getStartedWebServersAndJvmsCount(@ApiParam(value = "The group name to query") @PathParam("groupName") String groupName);
 
     @GET
     @Path("/{groupName}/children/startedAndStoppedCount")
-    @ApiOperation(value = "Get number of started and stopped webservers, JVMs count of a group",
+    @ApiOperation(value = "Get number of started and stopped web servers, JVMs count of a group",
             response = Long.class
     )
     Response getStartedAndStoppedWebServersAndJvmsCount(@ApiParam(value = "The group name to query") @PathParam("groupName") String groupName);
 
     @GET
     @Path("/children/stoppedCount")
-    @ApiOperation(value = "Get stopped webservers and JVMs count",
+    @ApiOperation(value = "Get stopped web servers and JVMs count",
             response = Long.class
     )
     Response getStoppedWebServersAndJvmsCount();
 
     @GET
     @Path("/{groupName}/children/stoppedCount")
-    @ApiOperation(value = "Get stopped webservers and JVMs count of a group",
+    @ApiOperation(value = "Get stopped web servers and JVMs count of a group",
             response = Long.class
     )
     Response getStoppedWebServersAndJvmsCount(@ApiParam(value = "The group name to query") @PathParam("groupName") String groupName);
@@ -375,7 +375,7 @@ public interface GroupServiceRest {
 
     @GET
     @Path("/{groupName}/webservers/allStopped")
-    @ApiOperation(value = "check if all webservers of a group are stopped",
+    @ApiOperation(value = "check if all web servers of a group are stopped",
             response = Map.class
     )
     Response areAllWebServersStopped(@ApiParam(value = "The group name to query") @PathParam("groupName") String groupName);

--- a/jwala-webservices/src/main/java/com/cerner/jwala/ws/rest/v1/service/group/GroupServiceRest.java
+++ b/jwala-webservices/src/main/java/com/cerner/jwala/ws/rest/v1/service/group/GroupServiceRest.java
@@ -93,7 +93,7 @@ public interface GroupServiceRest {
             response = CommandOutput.class
     )
     Response controlGroupJvms(@ApiParam(value = "The group ID to query") @PathParam("groupId") final Identifier<Group> aGroupId,
-                              @ApiParam(value = "The control group jvms operation") final JsonControlJvm jvmControlOperation,
+                              @ApiParam(value = "The control group JVMs operation") final JsonControlJvm jvmControlOperation,
                               @BeanParam final AuthenticatedUser aUser);
 
     /*********************
@@ -326,49 +326,49 @@ public interface GroupServiceRest {
 
     @GET
     @Path("/children/startedCount")
-    @ApiOperation(value = "Get number of started webservers and jvms count",
+    @ApiOperation(value = "Get number of started webservers and JVMs count",
             response = Long.class
     )
     Response getStartedWebServersAndJvmsCount();
 
     @GET
     @Path("/children/startedAndStoppedCount")
-    @ApiOperation(value = "Get number of started and stopped webservers, jvms count",
+    @ApiOperation(value = "Get number of started and stopped webservers, JVMs count",
             response = Long.class
     )
     Response getStartedAndStoppedWebServersAndJvmsCount();
 
     @GET
     @Path("/{groupName}/children/startedCount")
-    @ApiOperation(value = "Get number of started webservers and jvms count of a group",
+    @ApiOperation(value = "Get number of started webservers and JVMs count of a group",
             response = Long.class
     )
     Response getStartedWebServersAndJvmsCount(@ApiParam(value = "The group name to query") @PathParam("groupName") String groupName);
 
     @GET
     @Path("/{groupName}/children/startedAndStoppedCount")
-    @ApiOperation(value = "Get number of started and stopped webservers, jvms count of a group",
+    @ApiOperation(value = "Get number of started and stopped webservers, JVMs count of a group",
             response = Long.class
     )
     Response getStartedAndStoppedWebServersAndJvmsCount(@ApiParam(value = "The group name to query") @PathParam("groupName") String groupName);
 
     @GET
     @Path("/children/stoppedCount")
-    @ApiOperation(value = "Get stopped webservers and jvms count",
+    @ApiOperation(value = "Get stopped webservers and JVMs count",
             response = Long.class
     )
     Response getStoppedWebServersAndJvmsCount();
 
     @GET
     @Path("/{groupName}/children/stoppedCount")
-    @ApiOperation(value = "Get stopped webservers and jvms count of a group",
+    @ApiOperation(value = "Get stopped webservers and JVMs count of a group",
             response = Long.class
     )
     Response getStoppedWebServersAndJvmsCount(@ApiParam(value = "The group name to query") @PathParam("groupName") String groupName);
 
     @GET
     @Path("/{groupName}/jvms/allStopped")
-    @ApiOperation(value = "check if all jvms of a group are stopped",
+    @ApiOperation(value = "check if all JVMs of a group are stopped",
             response = Map.class
     )
     Response areAllJvmsStopped(@ApiParam(value = "The group name to query") @PathParam("groupName") String groupName);

--- a/jwala-webservices/src/main/java/com/cerner/jwala/ws/rest/v1/service/group/GroupServiceRest.java
+++ b/jwala-webservices/src/main/java/com/cerner/jwala/ws/rest/v1/service/group/GroupServiceRest.java
@@ -71,7 +71,7 @@ public interface GroupServiceRest {
 
     @POST
     @Path("/{groupId}/jvms")
-    @ApiOperation(value = "Add JVMS to group",
+    @ApiOperation(value = "Add JVMs to a group",
             response = Group.class
     )
     Response addJvmsToGroup(@ApiParam(value = "The group ID to query") @PathParam("groupId") final Identifier<Group> aGroupId,
@@ -80,7 +80,7 @@ public interface GroupServiceRest {
 
     @DELETE
     @Path("/{groupId}/jvms/{jvmId}")
-    @ApiOperation(value = "Remove JVMS from group",
+    @ApiOperation(value = "Remove JVMS from a group",
             response = Group.class
     )
     Response removeJvmFromGroup(@ApiParam(value = "The group ID to query") @PathParam("groupId") final Identifier<Group> aGroupId,
@@ -104,7 +104,7 @@ public interface GroupServiceRest {
     @ApiOperation(value = "Generate and deploy group JVM file",
             response = Group.class
     )
-    @ApiResponses(@ApiResponse(code = 500, message = "Failed for web server"))
+    @ApiResponses(@ApiResponse(code = 500, message = "Failed for generate and deploy a group JVM resource file"))
     Response generateAndDeployGroupJvmFile(@ApiParam(value = "The group name to query") @PathParam("groupName") String groupName,
                                            @ApiParam(value = "The file name to deploy") @PathParam("fileName") String fileName,
                                            @BeanParam AuthenticatedUser authUser);
@@ -128,7 +128,7 @@ public interface GroupServiceRest {
     @PUT
     @Path("/{groupName}/jvms/resources/preview/{resourceTemplateName}")
     @Consumes(MediaType.TEXT_PLAIN)
-    @ApiOperation(value = "Preview group jvm resource template",
+    @ApiOperation(value = "Preview group JVM resource template",
             response = String.class
     )
     @ApiResponses(@ApiResponse(code = 500, message = "Failed to preview group JVM resource template"))
@@ -162,7 +162,7 @@ public interface GroupServiceRest {
 
     @GET
     @Path("/{groupName}/webservers/resources/name")
-    @ApiOperation(value = "Get group webservers resource names",
+    @ApiOperation(value = "Get group webserver resource names",
             response = List.class
     )
     Response getGroupWebServersResourceNames(@ApiParam(value = "The group name to query") @PathParam("groupName") final String groupName);
@@ -222,7 +222,7 @@ public interface GroupServiceRest {
     @PUT
     @Path("/{groupName}/{appName}/apps/resources/template/{resourceTemplateName}")
     @Consumes(MediaType.TEXT_PLAIN)
-    @ApiOperation(value = "Update group app resource template",
+    @ApiOperation(value = "Update group application resource template",
             response = String.class
     )
     @ApiResponses(@ApiResponse(code = 500, message = "Failed to group application resource template"))
@@ -233,7 +233,7 @@ public interface GroupServiceRest {
     @PUT
     @Path("/{groupName}/apps/resources/preview/{resourceTemplateName}/{appName}")
     @Consumes(MediaType.TEXT_PLAIN)
-    @ApiOperation(value = "Get group app resource names",
+    @ApiOperation(value = "Preview group application resource names",
             response = String.class
     )
     @ApiResponses(@ApiResponse(code = 500, message = "Failed to preview group application resource template"))
@@ -368,14 +368,14 @@ public interface GroupServiceRest {
 
     @GET
     @Path("/{groupName}/jvms/allStopped")
-    @ApiOperation(value = "Are all jvms of a group stopped",
+    @ApiOperation(value = "check if all jvms of a group are stopped",
             response = Map.class
     )
     Response areAllJvmsStopped(@ApiParam(value = "The group name to query") @PathParam("groupName") String groupName);
 
     @GET
     @Path("/{groupName}/webservers/allStopped")
-    @ApiOperation(value = "Are all webservers of a group stopped",
+    @ApiOperation(value = "check if all webservers of a group are stopped",
             response = Map.class
     )
     Response areAllWebServersStopped(@ApiParam(value = "The group name to query") @PathParam("groupName") String groupName);
@@ -410,7 +410,7 @@ public interface GroupServiceRest {
      */
     @GET
     @Path("/{groupName}/state")
-    @ApiOperation(value = "Get group state",
+    @ApiOperation(value = "Get group state of a specific group",
             response = CurrentState.class
     )
     Response getGroupState(@ApiParam(value = "The group name to query") @PathParam("groupName") String groupName);

--- a/jwala-webservices/src/main/java/com/cerner/jwala/ws/rest/v1/service/group/GroupServiceRest.java
+++ b/jwala-webservices/src/main/java/com/cerner/jwala/ws/rest/v1/service/group/GroupServiceRest.java
@@ -3,6 +3,9 @@ package com.cerner.jwala.ws.rest.v1.service.group;
 import com.cerner.jwala.common.domain.model.group.Group;
 import com.cerner.jwala.common.domain.model.id.Identifier;
 import com.cerner.jwala.common.domain.model.jvm.Jvm;
+import com.cerner.jwala.common.domain.model.state.CurrentState;
+import com.cerner.jwala.common.domain.model.webserver.WebServer;
+import com.cerner.jwala.common.exec.CommandOutput;
 import com.cerner.jwala.ws.rest.v1.provider.AuthenticatedUser;
 import com.cerner.jwala.ws.rest.v1.provider.NameSearchParameterProvider;
 import com.cerner.jwala.ws.rest.v1.service.group.impl.JsonControlGroup;
@@ -10,56 +13,87 @@ import com.cerner.jwala.ws.rest.v1.service.group.impl.JsonJvms;
 import com.cerner.jwala.ws.rest.v1.service.group.impl.JsonUpdateGroup;
 import com.cerner.jwala.ws.rest.v1.service.jvm.impl.JsonControlJvm;
 import com.cerner.jwala.ws.rest.v1.service.webserver.impl.JsonControlWebServer;
+import io.swagger.annotations.*;
 
 import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import java.util.List;
+import java.util.Map;
 
+@Api(value = "/groups", tags = "groups")
 @Path("/groups")
 @Produces(MediaType.APPLICATION_JSON)
 
 public interface GroupServiceRest {
 
     @GET
+    @ApiOperation(value = "Get the data for all of the groups",
+            response = Group.class
+    )
     Response getGroups(@BeanParam final NameSearchParameterProvider aGroupNameSearch,
-                       @QueryParam("webServers") final boolean fetchWebServers);
+                       @ApiParam(value = "The boolean value to fetch webservers data", required = true) @QueryParam("webServers") final boolean fetchWebServers);
 
     @GET
     @Path("/{groupIdOrName}")
-    Response getGroup(@PathParam("groupIdOrName") String groupIdOrName,
-                      @QueryParam("byName") @DefaultValue("false") boolean byName);
+    @ApiOperation(value = "Get the data for a specific Group by the Group ID or Name",
+            response = Group.class
+    )
+    Response getGroup(@ApiParam(value = "The group id or name to query") @PathParam("groupIdOrName") String groupIdOrName,
+                      @ApiParam(value = "The boolean value to search group by name") @QueryParam("byName") @DefaultValue("false") boolean byName);
 
     @POST
     @Consumes(MediaType.APPLICATION_JSON)
-    Response createGroup(final String aNewGroupName,
+    @ApiOperation(value = "Create a new group",
+            response = Group.class
+    )
+    @ApiResponses(@ApiResponse(code = 500, message = "Group already exists with the provided name"))
+    Response createGroup(@ApiParam(value = "The group name to use") final String aNewGroupName,
                          @BeanParam final AuthenticatedUser aUser);
 
     @PUT
     @Consumes(MediaType.APPLICATION_JSON)
-    Response updateGroup(final JsonUpdateGroup anUpdatedGroup,
+    @ApiOperation(value = "Update an existing group",
+            response = Group.class
+    )
+    @ApiResponses(@ApiResponse(code = 500, message = "Failed to update group"))
+    Response updateGroup(@ApiParam(value = "The updated group details") final JsonUpdateGroup anUpdatedGroup,
                          @BeanParam final AuthenticatedUser aUser);
 
     @DELETE
     @Path("/{groupIdOrName}")
-    Response removeGroup(@PathParam("groupIdOrName") String name,
-                         @QueryParam("byName") @DefaultValue("false") boolean byName);
+    @ApiOperation(value = "Delete an existing group by ID or name",
+            response = Response.class
+    )
+    @ApiResponses(@ApiResponse(code = 500, message = "Failed to remove group"))
+    Response removeGroup(@ApiParam(value = "The group ID or name to query") @PathParam("groupIdOrName") String name,
+                         @ApiParam(value = "The boolean value to delete group by name") @QueryParam("byName") @DefaultValue("false") boolean byName);
 
     @POST
     @Path("/{groupId}/jvms")
-    Response addJvmsToGroup(@PathParam("groupId") final Identifier<Group> aGroupId,
-                            final JsonJvms someJvmsToAdd,
+    @ApiOperation(value = "Add JVMS to group",
+            response = Group.class
+    )
+    Response addJvmsToGroup(@ApiParam(value = "The group ID to query") @PathParam("groupId") final Identifier<Group> aGroupId,
+                            @ApiParam(value = "The JVMs to add in a group") final JsonJvms someJvmsToAdd,
                             @BeanParam final AuthenticatedUser aUser);
 
     @DELETE
     @Path("/{groupId}/jvms/{jvmId}")
-    Response removeJvmFromGroup(@PathParam("groupId") final Identifier<Group> aGroupId,
-                                @PathParam("jvmId") final Identifier<Jvm> aJvmId,
+    @ApiOperation(value = "Remove JVMS from group",
+            response = Group.class
+    )
+    Response removeJvmFromGroup(@ApiParam(value = "The group ID to query") @PathParam("groupId") final Identifier<Group> aGroupId,
+                                @ApiParam(value = "The JVM IDs to remove from group") @PathParam("jvmId") final Identifier<Jvm> aJvmId,
                                 @BeanParam final AuthenticatedUser aUser);
 
     @POST
     @Path("/{groupId}/jvms/commands")
-    Response controlGroupJvms(@PathParam("groupId") final Identifier<Group> aGroupId,
-                              final JsonControlJvm jvmControlOperation,
+    @ApiOperation(value = "Start all the JVMs of a group",
+            response = CommandOutput.class
+    )
+    Response controlGroupJvms(@ApiParam(value = "The group ID to query") @PathParam("groupId") final Identifier<Group> aGroupId,
+                              @ApiParam(value = "The control group jvms operation") final JsonControlJvm jvmControlOperation,
                               @BeanParam final AuthenticatedUser aUser);
 
     /*********************
@@ -67,32 +101,51 @@ public interface GroupServiceRest {
      *********************/
     @PUT
     @Path("/{groupName}/jvms/conf/{fileName}")
-    Response generateAndDeployGroupJvmFile(@PathParam("groupName") String groupName, @PathParam("fileName") String fileName,
+    @ApiOperation(value = "Generate and deploy group JVM file",
+            response = Group.class
+    )
+    @ApiResponses(@ApiResponse(code = 500, message = "Failed for web server"))
+    Response generateAndDeployGroupJvmFile(@ApiParam(value = "The group name to query") @PathParam("groupName") String groupName,
+                                           @ApiParam(value = "The file name to deploy") @PathParam("fileName") String fileName,
                                            @BeanParam AuthenticatedUser authUser);
 
     @GET
     @Path("/{groupName}/jvms/resources/name")
-    Response getGroupJvmsResourceNames(@PathParam("groupName") final String groupName);
+    @ApiOperation(value = "Get group JVM resource names",
+            response = String.class
+    )
+    Response getGroupJvmsResourceNames(@ApiParam(value = "The group name to query")@PathParam("groupName") final String groupName);
 
     @GET
     @Path("/{groupName}/jvms/resources/template/{resourceTemplateName}")
-    Response getGroupJvmResourceTemplate(@PathParam("groupName") final String groupName,
-                                         @PathParam("resourceTemplateName") final String resourceTemplateName,
-                                         @QueryParam("tokensReplaced") final boolean tokensReplaced);
+    @ApiOperation(value = "Get group JVM resource template",
+            response = String.class
+    )
+    Response getGroupJvmResourceTemplate(@ApiParam(value = "The group name to query") @PathParam("groupName") final String groupName,
+                                         @ApiParam(value = "The resource template name") @PathParam("resourceTemplateName") final String resourceTemplateName,
+                                         @ApiParam(value = "boolean value for token replaced") @QueryParam("tokensReplaced") final boolean tokensReplaced);
 
     @PUT
     @Path("/{groupName}/jvms/resources/preview/{resourceTemplateName}")
     @Consumes(MediaType.TEXT_PLAIN)
-    Response previewGroupJvmResourceTemplate(@PathParam("groupName") String groupName,
-                                             @PathParam("resourceTemplateName") final String resourceTemplateName,
-                                             String template);
+    @ApiOperation(value = "Preview group jvm resource template",
+            response = String.class
+    )
+    @ApiResponses(@ApiResponse(code = 500, message = "Failed to preview group JVM resource template"))
+    Response previewGroupJvmResourceTemplate(@ApiParam(value = "The group name to query") @PathParam("groupName") String groupName,
+                                             @ApiParam(value = "The resource template name") @PathParam("resourceTemplateName") final String resourceTemplateName,
+                                             @ApiParam(value = "The group JVM resource template") String template);
 
     @PUT
     @Path("/{groupName}/jvms/resources/template/{resourceTemplateName}")
     @Consumes(MediaType.TEXT_PLAIN)
-    Response updateGroupJvmResourceTemplate(@PathParam("groupName") final String groupName,
-                                            @PathParam("resourceTemplateName") final String resourceTemplateName,
-                                            final String content);
+    @ApiOperation(value = "Update group JVM resource template",
+            response = String.class
+    )
+    @ApiResponses(@ApiResponse(code = 500, message = "Failed to update group JVM resource template"))
+    Response updateGroupJvmResourceTemplate(@ApiParam(value = "The group name to query") @PathParam("groupName") final String groupName,
+                                            @ApiParam(value = "The resource template name") @PathParam("resourceTemplateName") final String resourceTemplateName,
+                                            @ApiParam(value = "The updated group JVM resource template content") final String content);
 
 
     /****************************
@@ -100,34 +153,51 @@ public interface GroupServiceRest {
      ****************************/
     @PUT
     @Path("/{groupName}/webservers/conf/{resourceFileName}")
-    Response generateAndDeployGroupWebServersFile(@PathParam("groupName") final String groupName,
-                                                  @PathParam("resourceFileName") @DefaultValue("httpd.conf")final String resourceFileName,
+    @ApiOperation(value = "Generate and deploy group webservers file",
+            response = String.class
+    )
+    Response generateAndDeployGroupWebServersFile(@ApiParam(value = "The group name to query") @PathParam("groupName") final String groupName,
+                                                  @ApiParam(value = "The resource file name")@PathParam("resourceFileName") @DefaultValue("httpd.conf")final String resourceFileName,
                                                   @BeanParam final AuthenticatedUser aUser);
 
     @GET
     @Path("/{groupName}/webservers/resources/name")
-    Response getGroupWebServersResourceNames(@PathParam("groupName") final String groupName);
+    @ApiOperation(value = "Get group webservers resource names",
+            response = List.class
+    )
+    Response getGroupWebServersResourceNames(@ApiParam(value = "The group name to query") @PathParam("groupName") final String groupName);
 
     @GET
     @Path("/{groupName}/webservers/resources/template/{resourceTemplateName}")
-    Response getGroupWebServerResourceTemplate(@PathParam("groupName") final String groupName,
-                                               @PathParam("resourceTemplateName") final String resourceTemplateName,
-                                               @QueryParam("tokensReplaced") final boolean tokensReplaced);
+    @ApiOperation(value = "Get group webserver resource template",
+            response = String.class
+    )
+    Response getGroupWebServerResourceTemplate(@ApiParam(value = "The group name to query") @PathParam("groupName") final String groupName,
+                                               @ApiParam(value = "The resource template name") @PathParam("resourceTemplateName") final String resourceTemplateName,
+                                               @ApiParam(value = "The boolean value for tokens replaced") @QueryParam("tokensReplaced") final boolean tokensReplaced);
 
     @PUT
     @Path("/{groupName}/webservers/resources/preview/{resourceTemplateName}")
     @Consumes(MediaType.TEXT_PLAIN)
-    Response previewGroupWebServerResourceTemplate(@PathParam("groupName") String groupName,
-                                                   @PathParam("resourceTemplateName") final String resourceTemplateName,
-                                                   String template);
+    @ApiOperation(value = "Preview group webserver resource template",
+            response = String.class
+    )
+    @ApiResponses(@ApiResponse(code = 500, message = "Failed to preview group Webserver resource template"))
+    Response previewGroupWebServerResourceTemplate(@ApiParam(value = "The group name to query") @PathParam("groupName") String groupName,
+                                                   @ApiParam(value = "The resource template name") @PathParam("resourceTemplateName") final String resourceTemplateName,
+                                                   @ApiParam(value = "The webserver resource resource template") String template);
 
 
     @PUT
     @Path("/{groupName}/webservers/resources/template/{resourceTemplateName}")
     @Consumes(MediaType.TEXT_PLAIN)
-    Response updateGroupWebServerResourceTemplate(@PathParam("groupName") final String groupName,
-                                                  @PathParam("resourceTemplateName") final String resourceTemplateName,
-                                                  final String content);
+    @ApiOperation(value = "Update group webserver resource template",
+            response = String.class
+    )
+    @ApiResponses(@ApiResponse(code = 500, message = "Failed to update group Webserver resource template"))
+    Response updateGroupWebServerResourceTemplate(@ApiParam(value = "The group name to query") @PathParam("groupName") final String groupName,
+                                                  @ApiParam(value = "The resource template name") @PathParam("resourceTemplateName") final String resourceTemplateName,
+                                                  @ApiParam(value = "The updated webserver resource template content") final String content);
 
     /********************
      * ** App Template ***
@@ -135,36 +205,54 @@ public interface GroupServiceRest {
 
     @GET
     @Path("/{groupName}/apps/resources/name")
-    Response getGroupAppResourceNames(@PathParam("groupName") final String groupName);
+    @ApiOperation(value = "Get group app resource names",
+            response = List.class
+    )
+    Response getGroupAppResourceNames(@ApiParam(value = "The group name to query") @PathParam("groupName") final String groupName);
 
     @GET
     @Path("/{groupName}/apps/resources/template/{resourceTemplateName}")
-    Response getGroupAppResourceTemplate(@PathParam("groupName") final String groupName,
-                                         String appName, @PathParam("resourceTemplateName") final String resourceTemplateName,
-                                         @QueryParam("tokensReplaced") final boolean tokensReplaced);
+    @ApiOperation(value = "Get group app resource template",
+            response = String.class
+    )
+    Response getGroupAppResourceTemplate(@ApiParam(value = "The group name to query") @PathParam("groupName") final String groupName,
+                                         @ApiParam(value = "The application name") String appName, @ApiParam(value = "The resource template name") @PathParam("resourceTemplateName") final String resourceTemplateName,
+                                         @ApiParam(value = "boolean value for tokens replaced")@QueryParam("tokensReplaced") final boolean tokensReplaced);
 
     @PUT
     @Path("/{groupName}/{appName}/apps/resources/template/{resourceTemplateName}")
     @Consumes(MediaType.TEXT_PLAIN)
-    Response updateGroupAppResourceTemplate(@PathParam("groupName") final String groupName, @PathParam("appName") String appName,
-                                            @PathParam("resourceTemplateName") final String resourceTemplateName,
-                                            final String content);
+    @ApiOperation(value = "Update group app resource template",
+            response = String.class
+    )
+    @ApiResponses(@ApiResponse(code = 500, message = "Failed to group application resource template"))
+    Response updateGroupAppResourceTemplate(@ApiParam(value = "The group name to query") @PathParam("groupName") final String groupName, @PathParam("appName") String appName,
+                                            @ApiParam(value = "The resource template name")@PathParam("resourceTemplateName") final String resourceTemplateName,
+                                            @ApiParam(value = "The resource template updated content") final String content);
 
     @PUT
     @Path("/{groupName}/apps/resources/preview/{resourceTemplateName}/{appName}")
     @Consumes(MediaType.TEXT_PLAIN)
-    Response previewGroupAppResourceTemplate(@PathParam("groupName") String groupName,
-                                             @PathParam("resourceTemplateName") String resourceTemplateName,
-                                             @PathParam("appName") String appName,
-                                             String template);
+    @ApiOperation(value = "Get group app resource names",
+            response = String.class
+    )
+    @ApiResponses(@ApiResponse(code = 500, message = "Failed to preview group application resource template"))
+    Response previewGroupAppResourceTemplate(@ApiParam(value = "The group name to query") @PathParam("groupName") String groupName,
+                                             @ApiParam(value = "The resource template name") @PathParam("resourceTemplateName") String resourceTemplateName,
+                                             @ApiParam(value = "The application name")@PathParam("appName") String appName,
+                                             @ApiParam(value = "The resource template content") String template);
 
     @PUT
     @Path("/{groupName}/apps/conf/{fileName}/{appName}")
-    Response generateAndDeployGroupAppFile(@PathParam("groupName") final String groupName,
-                                           @PathParam("fileName") final String fileName,
-                                           @PathParam("appName") final String appName,
+    @ApiOperation(value = "Generate and deploy group application file",
+            response = Group.class
+    )
+    @ApiResponses(@ApiResponse(code = 500, message = "Failed to generate and deploy group application file"))
+    Response generateAndDeployGroupAppFile(@ApiParam(value = "The group name to query") @PathParam("groupName") final String groupName,
+                                           @ApiParam(value = "The file name to deploy") @PathParam("fileName") final String fileName,
+                                           @ApiParam(value = "The application name") @PathParam("appName") final String appName,
                                            @BeanParam final AuthenticatedUser aUser,
-                                           @QueryParam("hostName") final String hostName);
+                                           @ApiParam(value = "The hostname of remote server") @QueryParam("hostName") final String hostName);
 
     /************************
      * ** Control Commands ***
@@ -172,8 +260,11 @@ public interface GroupServiceRest {
 
     @POST
     @Path("/{groupId}/commands")
-    Response controlGroup(@PathParam("groupId") final Identifier<Group> aGroupId,
-                          final JsonControlGroup groupControlOperation,
+    @ApiOperation(value = "Control group start or stop",
+            response = CommandOutput.class
+    )
+    Response controlGroup(@ApiParam(value = "The group ID to query") @PathParam("groupId") final Identifier<Group> aGroupId,
+                          @ApiParam(value = "The control group operation") final JsonControlGroup groupControlOperation,
                           @BeanParam final AuthenticatedUser aUser);
 
     /**
@@ -184,23 +275,37 @@ public interface GroupServiceRest {
      */
     @POST
     @Path("/commands")
-    Response controlGroups(JsonControlGroup jsonControlGroup, @BeanParam AuthenticatedUser authenticatedUser);
+    @ApiOperation(value = "The control all groups start or stop",
+            response = CommandOutput.class
+    )
+    Response controlGroups(@ApiParam(value = "The control group operation for all groups") JsonControlGroup jsonControlGroup, @BeanParam AuthenticatedUser authenticatedUser);
 
     @POST
     @Path("/{groupId}/webservers/commands")
-    Response controlGroupWebservers(@PathParam("groupId") final Identifier<Group> aGroupId,
-                                    final JsonControlWebServer jsonControlWebServer,
+    @ApiOperation(value = "Start all the webservers of a group",
+            response = CommandOutput.class
+    )
+    Response controlGroupWebservers(@ApiParam(value = "The group ID to query") @PathParam("groupId") final Identifier<Group> aGroupId,
+                                    @ApiParam(value = "The control group operation to start or stop all webservers") final JsonControlWebServer jsonControlWebServer,
                                     @BeanParam final AuthenticatedUser aUser);
 
 
     @POST
     @Path("/{groupId}/webservers/conf/deploy")
-    Response generateGroupWebservers(@PathParam("groupId") final Identifier<Group> aGroupId,
+    @ApiOperation(value = "Generate group webservers",
+            response = Group.class
+    )
+    @ApiResponses(@ApiResponse(code = 500, message = "Failed to generate group webservers"))
+    Response generateGroupWebservers(@ApiParam(value = "The group ID to query") @PathParam("groupId") final Identifier<Group> aGroupId,
                                      @BeanParam final AuthenticatedUser aUser);
 
     @POST
     @Path("/{groupId}/jvms/conf/deploy")
-    Response generateGroupJvms(@PathParam("groupId") final Identifier<Group> aGroupId,
+    @ApiOperation(value = "Generate group JVMs",
+            response = Group.class
+    )
+    @ApiResponses(@ApiResponse(code = 500, message = "Failed to generate group JVMs"))
+    Response generateGroupJvms(@ApiParam(value = "The group ID to query") @PathParam("groupId") final Identifier<Group> aGroupId,
                                @BeanParam final AuthenticatedUser aUser);
 
     /**
@@ -213,40 +318,67 @@ public interface GroupServiceRest {
      */
     @GET
     @Path("/{groupId}/children/otherGroup/connectionDetails")
-    Response getOtherGroupMembershipDetailsOfTheChildren(@PathParam("groupId") final Identifier<Group> id,
-                                                         @QueryParam("groupChildType") final GroupChildType groupChildType);
+    @ApiOperation(value = "Get other group membership details of the children",
+            response = WebServer.class
+    )
+    Response getOtherGroupMembershipDetailsOfTheChildren(@ApiParam(value = "The group ID to query") @PathParam("groupId") final Identifier<Group> id,
+                                                         @ApiParam(value = "The group child type") @QueryParam("groupChildType") final GroupChildType groupChildType);
 
     @GET
     @Path("/children/startedCount")
+    @ApiOperation(value = "Get number of started webservers and jvms count",
+            response = Long.class
+    )
     Response getStartedWebServersAndJvmsCount();
 
     @GET
     @Path("/children/startedAndStoppedCount")
+    @ApiOperation(value = "Get number of started and stopped webservers, jvms count",
+            response = Long.class
+    )
     Response getStartedAndStoppedWebServersAndJvmsCount();
 
     @GET
     @Path("/{groupName}/children/startedCount")
-    Response getStartedWebServersAndJvmsCount(@PathParam("groupName") String groupName);
+    @ApiOperation(value = "Get number of started webservers and jvms count of a group",
+            response = Long.class
+    )
+    Response getStartedWebServersAndJvmsCount(@ApiParam(value = "The group name to query") @PathParam("groupName") String groupName);
 
     @GET
     @Path("/{groupName}/children/startedAndStoppedCount")
-    Response getStartedAndStoppedWebServersAndJvmsCount(@PathParam("groupName") String groupName);
+    @ApiOperation(value = "Get number of started and stopped webservers, jvms count of a group",
+            response = Long.class
+    )
+    Response getStartedAndStoppedWebServersAndJvmsCount(@ApiParam(value = "The group name to query") @PathParam("groupName") String groupName);
 
     @GET
     @Path("/children/stoppedCount")
+    @ApiOperation(value = "Get stopped webservers and jvms count",
+            response = Long.class
+    )
     Response getStoppedWebServersAndJvmsCount();
 
     @GET
     @Path("/{groupName}/children/stoppedCount")
-    Response getStoppedWebServersAndJvmsCount(@PathParam("groupName") String groupName);
+    @ApiOperation(value = "Get stopped webservers and jvms count of a group",
+            response = Long.class
+    )
+    Response getStoppedWebServersAndJvmsCount(@ApiParam(value = "The group name to query") @PathParam("groupName") String groupName);
 
     @GET
     @Path("/{groupName}/jvms/allStopped")
-    Response areAllJvmsStopped(@PathParam("groupName") String groupName);
+    @ApiOperation(value = "Are all jvms of a group stopped",
+            response = Map.class
+    )
+    Response areAllJvmsStopped(@ApiParam(value = "The group name to query") @PathParam("groupName") String groupName);
 
     @GET
     @Path("/{groupName}/webservers/allStopped")
-    Response areAllWebServersStopped(@PathParam("groupName") String groupName);
+    @ApiOperation(value = "Are all webservers of a group stopped",
+            response = Map.class
+    )
+    Response areAllWebServersStopped(@ApiParam(value = "The group name to query") @PathParam("groupName") String groupName);
 
     /**
      * Get hosts of a group.
@@ -255,7 +387,10 @@ public interface GroupServiceRest {
      */
     @GET
     @Path("/{groupName}/hosts")
-    Response getHosts(@PathParam("groupName") String groupName);
+    @ApiOperation(value = "Get all hosts of a group",
+            response = List.class
+    )
+    Response getHosts(@ApiParam(value = "The group name to query") @PathParam("groupName") String groupName);
 
     /**
      * Return all the unique host names configured for all the groups
@@ -263,6 +398,9 @@ public interface GroupServiceRest {
      */
     @GET
     @Path("/hosts")
+    @ApiOperation(value = "Get all hosts",
+            response = List.class
+    )
     Response getAllHosts();
 
     /**
@@ -272,7 +410,10 @@ public interface GroupServiceRest {
      */
     @GET
     @Path("/{groupName}/state")
-    Response getGroupState(@PathParam("groupName") String groupName);
+    @ApiOperation(value = "Get group state",
+            response = CurrentState.class
+    )
+    Response getGroupState(@ApiParam(value = "The group name to query") @PathParam("groupName") String groupName);
 
     /**
      * Gets the state info of all groups
@@ -280,6 +421,9 @@ public interface GroupServiceRest {
      */
     @GET
     @Path("/state")
+    @ApiOperation(value = "Get all group states",
+            response = Map.class
+    )
     Response getGroupStates();
 
 }

--- a/jwala-webservices/src/main/java/com/cerner/jwala/ws/rest/v1/service/jvm/JvmServiceRest.java
+++ b/jwala-webservices/src/main/java/com/cerner/jwala/ws/rest/v1/service/jvm/JvmServiceRest.java
@@ -6,10 +6,7 @@ import com.cerner.jwala.ws.rest.v1.provider.AuthenticatedUser;
 import com.cerner.jwala.ws.rest.v1.service.jvm.impl.JsonControlJvm;
 import com.cerner.jwala.ws.rest.v1.service.jvm.impl.JsonCreateJvm;
 import com.cerner.jwala.ws.rest.v1.service.jvm.impl.JsonUpdateJvm;
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiResponse;
-import io.swagger.annotations.ApiResponses;
+import io.swagger.annotations.*;
 
 import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
@@ -32,7 +29,7 @@ public interface JvmServiceRest {
     @ApiOperation(value = "Get a single jvm by ID",
             response = Jvm.class
     )
-    Response getJvm(@PathParam("jvmId") final Identifier<Jvm> aJvmId);
+    Response getJvm(@ApiParam(value = "The jvm's ID", required = true) @PathParam("jvmId") final Identifier<Jvm> aJvmId);
 
     @POST
     @Consumes(MediaType.APPLICATION_JSON)
@@ -40,7 +37,7 @@ public interface JvmServiceRest {
             response = Jvm.class
     )
     @ApiResponses(@ApiResponse(code = 500, message = "Jvm already exists"))
-    Response createJvm(JsonCreateJvm jsonCreateJvm, @BeanParam AuthenticatedUser aUser);
+    Response createJvm(@ApiParam(value = "The configuration info for the jvm to be created", required = true) JsonCreateJvm jsonCreateJvm, @BeanParam AuthenticatedUser aUser);
 
     @PUT
     @Consumes(MediaType.APPLICATION_JSON)
@@ -48,7 +45,7 @@ public interface JvmServiceRest {
             response = Jvm.class
     )
     @ApiResponses(@ApiResponse(code = 500, message = "Failed to update the jvm"))
-    Response updateJvm(JsonUpdateJvm aJvmToUpdate, @QueryParam("updateJvmPassword") boolean updateJvmPassword,
+    Response updateJvm(@ApiParam(value = "The configuration info for the jvm to be updated", required = true) JsonUpdateJvm aJvmToUpdate, @QueryParam("updateJvmPassword") boolean updateJvmPassword,
                        @BeanParam AuthenticatedUser aUser);
 
     @DELETE
@@ -57,7 +54,7 @@ public interface JvmServiceRest {
             response = Response.class
     )
     @ApiResponses(@ApiResponse(code = 500, message = "Unable to delete jvm"))
-    Response deleteJvm(@PathParam("jvmId") Identifier<Jvm> id, @QueryParam("hardDelete") boolean hardDelete,
+    Response deleteJvm(@ApiParam(value = "The ID of the jvm to be deleted", required = true) @PathParam("jvmId") Identifier<Jvm> id, @ApiParam(value = "Deletes the jvm and its service when set to true; only deletes the jvm when false", required = true) @QueryParam("hardDelete") boolean hardDelete,
                        @BeanParam final AuthenticatedUser user);
 
     /**
@@ -75,10 +72,10 @@ public interface JvmServiceRest {
             response = String.class
     )
     @ApiResponses(@ApiResponse(code = 500, message = "Jvm operation unsuccessful"))
-    Response controlJvm(@PathParam("jvmId") final Identifier<Jvm> aJvmId,
-                        final JsonControlJvm aJvmToControl,
-                        @QueryParam("wait") Boolean wait,
-                        @QueryParam("timeout") Long waitTimeout,
+    Response controlJvm(@ApiParam(value = "The ID of the jvm", required = true) @PathParam("jvmId") final Identifier<Jvm> aJvmId,
+                        @ApiParam(value = "The control operation to execute", required = true) final JsonControlJvm aJvmToControl,
+                        @ApiParam(value = "If set to true then block the thread until the control operation returns", required = true) @QueryParam("wait") Boolean wait,
+                        @ApiParam(value = "When 'wait=true' set a maximum time to block the thread", required = true) @QueryParam("timeout") Long waitTimeout,
                         @BeanParam final AuthenticatedUser aUser);
 
     /**
@@ -93,7 +90,7 @@ public interface JvmServiceRest {
             response = Jvm.class
     )
     @ApiResponses(@ApiResponse(code = 500, message = "Remote generation of jvm failed"))
-    Response generateAndDeployJvm(@PathParam("jvmName") final String jvmName,
+    Response generateAndDeployJvm(@ApiParam(value = "The name of the jvm to generated", required = true) @PathParam("jvmName") final String jvmName,
                                   @BeanParam final AuthenticatedUser aUser);
 
     /**
@@ -109,8 +106,8 @@ public interface JvmServiceRest {
             response = Jvm.class
     )
     @ApiResponses(@ApiResponse(code = 500, message = "Failed to deploy jvm resource"))
-    Response generateAndDeployFile(@PathParam("jvmName") final String jvmName,
-                                   @PathParam("fileName") final String fileName,
+    Response generateAndDeployFile(@ApiParam(value = "The name of the jvm associated with the resource", required = true) @PathParam("jvmName") final String jvmName,
+                                   @ApiParam(value = "The name of the resource to be generated and deployed", required = true) @PathParam("fileName") final String fileName,
                                    @BeanParam final AuthenticatedUser aUser);
 
     /**
@@ -123,14 +120,14 @@ public interface JvmServiceRest {
     @ApiOperation(value = "Initiate a heartbeat followed by an SSH check",
             response = String.class
     )
-    Response diagnoseJvm(@PathParam("jvmId") final Identifier<Jvm> aJvmId, @BeanParam final AuthenticatedUser aUser);
+    Response diagnoseJvm(@ApiParam(value = "The id of the jvm whose state needs to be diagnosed", required = true) @PathParam("jvmId") final Identifier<Jvm> aJvmId, @BeanParam final AuthenticatedUser aUser);
 
     @GET
     @Path("/{jvmName}/resources/name")
     @ApiOperation(value = "Get all the resources corresponding to a specific jvm",
             response = List.class
     )
-    Response getResourceNames(@PathParam("jvmName") final String jvmName);
+    Response getResourceNames(@ApiParam(value = "The name of the jvm for which corresponding all resources are to be obtained", required = true) @PathParam("jvmName") final String jvmName);
 
     /**
      * Get resource template content.
@@ -144,9 +141,9 @@ public interface JvmServiceRest {
     @ApiOperation(value = "Get the template of a file for the given jvm and file name",
             response = String.class
     )
-    Response getResourceTemplate(@PathParam("jvmName") final String jvmName,
-                                 @PathParam("resourceTemplateName") final String resourceTemplateName,
-                                 @QueryParam("tokensReplaced") final boolean tokensReplaced);
+    Response getResourceTemplate(@ApiParam(value = "The name of the jvm", required = true) @PathParam("jvmName") final String jvmName,
+                                 @ApiParam(value = "The name of the resource", required = true) @PathParam("resourceTemplateName") final String resourceTemplateName,
+                                 @ApiParam(value = "If true then return the generated template, else return the raw template", required = true) @QueryParam("tokensReplaced") final boolean tokensReplaced);
 
     @PUT
     @Path("/{jvmName}/resources/template/{resourceTemplateName}")
@@ -156,9 +153,9 @@ public interface JvmServiceRest {
     )
     @ApiResponses(@ApiResponse(code = 500, message = "Failed to update the template"))
         // TODO: Pass authenticated user.
-    Response updateResourceTemplate(@PathParam("jvmName") final String jvmName,
-                                    @PathParam("resourceTemplateName") final String resourceTemplateName,
-                                    final String content);
+    Response updateResourceTemplate(@ApiParam(value = "The name of the jvm", required = true) @PathParam("jvmName") final String jvmName,
+                                    @ApiParam(value = "The name of the resource", required = true) @PathParam("resourceTemplateName") final String resourceTemplateName,
+                                    @ApiParam(value = "The new content of the resource", required = true) final String content);
 
     /**
      * Request a preview a resource file.
@@ -174,9 +171,9 @@ public interface JvmServiceRest {
             response = String.class
     )
     @ApiResponses(@ApiResponse(code = 500, message = "Error previewing template"))
-    Response previewResourceTemplate(@PathParam("jvmName") String jvmName,
-                                     @PathParam("resourceTemplateName") final String resourceTemplateName,
-                                     @MatrixParam("groupName") String groupName,
-                                     String template);
+    Response previewResourceTemplate(@ApiParam(value = "The name of the jvm", required = true) @PathParam("jvmName") String jvmName,
+                                     @ApiParam(value = "The name of the resource to preview", required = true) @PathParam("resourceTemplateName") final String resourceTemplateName,
+                                     @ApiParam(value = "The name of the jvm's group", required = true) @MatrixParam("groupName") String groupName,
+                                     @ApiParam(value = "The content to be generated", required = true) String template);
 
 }

--- a/jwala-webservices/src/main/java/com/cerner/jwala/ws/rest/v1/service/jvm/JvmServiceRest.java
+++ b/jwala-webservices/src/main/java/com/cerner/jwala/ws/rest/v1/service/jvm/JvmServiceRest.java
@@ -47,6 +47,7 @@ public interface JvmServiceRest {
     @ApiOperation(value = "Update an existing jvm",
             response = Jvm.class
     )
+    @ApiResponses(@ApiResponse(code = 500, message = "Failed to update the jvm"))
     Response updateJvm(JsonUpdateJvm aJvmToUpdate, @QueryParam("updateJvmPassword") boolean updateJvmPassword,
                        @BeanParam AuthenticatedUser aUser);
 
@@ -91,6 +92,7 @@ public interface JvmServiceRest {
     @ApiOperation(value = "Generates and deploy all JVM resource files",
             response = Jvm.class
     )
+    @ApiResponses(@ApiResponse(code = 500, message = "Remote generation of jvm failed"))
     Response generateAndDeployJvm(@PathParam("jvmName") final String jvmName,
                                   @BeanParam final AuthenticatedUser aUser);
 
@@ -106,6 +108,7 @@ public interface JvmServiceRest {
     @ApiOperation(value = "Generates and deploy a single JVM resource file as specified by the fileName",
             response = Jvm.class
     )
+    @ApiResponses(@ApiResponse(code = 500, message = "Failed to deploy jvm resource"))
     Response generateAndDeployFile(@PathParam("jvmName") final String jvmName,
                                    @PathParam("fileName") final String fileName,
                                    @BeanParam final AuthenticatedUser aUser);
@@ -151,6 +154,7 @@ public interface JvmServiceRest {
     @ApiOperation(value = "Update an existing jvm template with the new content provided",
             response = String.class
     )
+    @ApiResponses(@ApiResponse(code = 500, message = "Failed to update the template"))
         // TODO: Pass authenticated user.
     Response updateResourceTemplate(@PathParam("jvmName") final String jvmName,
                                     @PathParam("resourceTemplateName") final String resourceTemplateName,
@@ -169,6 +173,7 @@ public interface JvmServiceRest {
     @ApiOperation(value = "View the contents of a jvm resource file",
             response = String.class
     )
+    @ApiResponses(@ApiResponse(code = 500, message = "Error previewing template"))
     Response previewResourceTemplate(@PathParam("jvmName") String jvmName,
                                      @PathParam("resourceTemplateName") final String resourceTemplateName,
                                      @MatrixParam("groupName") String groupName,

--- a/jwala-webservices/src/main/java/com/cerner/jwala/ws/rest/v1/service/jvm/JvmServiceRest.java
+++ b/jwala-webservices/src/main/java/com/cerner/jwala/ws/rest/v1/service/jvm/JvmServiceRest.java
@@ -33,7 +33,7 @@ public interface JvmServiceRest {
 
     @POST
     @Consumes(MediaType.APPLICATION_JSON)
-    @ApiOperation(value = "Create a JVM",
+    @ApiOperation(value = "Create a JVM on Jwala database, The actual JVM instance on the server is created only after generate operation",
             response = Jvm.class
     )
     @ApiResponses(@ApiResponse(code = 500, message = "JVM already exists"))
@@ -50,7 +50,7 @@ public interface JvmServiceRest {
 
     @DELETE
     @Path("/{jvmId}")
-    @ApiOperation(value = "Delete an existing JVM",
+    @ApiOperation(value = "Delete an existing JVM with the boolean hardDelete, when set to true it will delete JVM from services and Jwala database and when set to false it will only delete the JVM from Jwala database",
             response = Response.class
     )
     @ApiResponses(@ApiResponse(code = 500, message = "Unable to delete JVM"))

--- a/jwala-webservices/src/main/java/com/cerner/jwala/ws/rest/v1/service/jvm/JvmServiceRest.java
+++ b/jwala-webservices/src/main/java/com/cerner/jwala/ws/rest/v1/service/jvm/JvmServiceRest.java
@@ -19,42 +19,42 @@ import java.util.List;
 public interface JvmServiceRest {
 
     @GET
-    @ApiOperation(value = "Get all the jvms",
+    @ApiOperation(value = "Get all the JVMs",
             response = List.class
     )
     Response getJvms();
 
     @GET
     @Path("/{jvmId}")
-    @ApiOperation(value = "Get a single jvm by ID",
+    @ApiOperation(value = "Get a single JVM by ID",
             response = Jvm.class
     )
-    Response getJvm(@ApiParam(value = "The jvm's ID", required = true) @PathParam("jvmId") final Identifier<Jvm> aJvmId);
+    Response getJvm(@ApiParam(value = "The JVM's ID", required = true) @PathParam("jvmId") final Identifier<Jvm> aJvmId);
 
     @POST
     @Consumes(MediaType.APPLICATION_JSON)
-    @ApiOperation(value = "Create a jvm",
+    @ApiOperation(value = "Create a JVM",
             response = Jvm.class
     )
-    @ApiResponses(@ApiResponse(code = 500, message = "Jvm already exists"))
-    Response createJvm(@ApiParam(value = "The configuration info for the jvm to be created", required = true) JsonCreateJvm jsonCreateJvm, @BeanParam AuthenticatedUser aUser);
+    @ApiResponses(@ApiResponse(code = 500, message = "JVM already exists"))
+    Response createJvm(@ApiParam(value = "The configuration info for the JVM to be created", required = true) JsonCreateJvm jsonCreateJvm, @BeanParam AuthenticatedUser aUser);
 
     @PUT
     @Consumes(MediaType.APPLICATION_JSON)
-    @ApiOperation(value = "Update an existing jvm",
+    @ApiOperation(value = "Update an existing JVM",
             response = Jvm.class
     )
-    @ApiResponses(@ApiResponse(code = 500, message = "Failed to update the jvm"))
-    Response updateJvm(@ApiParam(value = "The configuration info for the jvm to be updated", required = true) JsonUpdateJvm aJvmToUpdate, @QueryParam("updateJvmPassword") boolean updateJvmPassword,
+    @ApiResponses(@ApiResponse(code = 500, message = "Failed to update the JVM"))
+    Response updateJvm(@ApiParam(value = "The configuration info for the JVM to be updated", required = true) JsonUpdateJvm aJvmToUpdate, @QueryParam("updateJvmPassword") boolean updateJvmPassword,
                        @BeanParam AuthenticatedUser aUser);
 
     @DELETE
     @Path("/{jvmId}")
-    @ApiOperation(value = "Delete an existing jvm",
+    @ApiOperation(value = "Delete an existing JVM",
             response = Response.class
     )
-    @ApiResponses(@ApiResponse(code = 500, message = "Unable to delete jvm"))
-    Response deleteJvm(@ApiParam(value = "The ID of the jvm to be deleted", required = true) @PathParam("jvmId") Identifier<Jvm> id, @ApiParam(value = "Deletes the jvm and its service when set to true; only deletes the jvm when false", required = true) @QueryParam("hardDelete") boolean hardDelete,
+    @ApiResponses(@ApiResponse(code = 500, message = "Unable to delete JVM"))
+    Response deleteJvm(@ApiParam(value = "The ID of the JVM to be deleted", required = true) @PathParam("jvmId") Identifier<Jvm> id, @ApiParam(value = "Deletes the JVM and its service when set to true; only deletes the JVM when false", required = true) @QueryParam("hardDelete") boolean hardDelete,
                        @BeanParam final AuthenticatedUser user);
 
     /**
@@ -68,11 +68,11 @@ public interface JvmServiceRest {
      */
     @POST
     @Path("/{jvmId}/commands")
-    @ApiOperation(value = "Start/stop a jvm or take a heap dump",
+    @ApiOperation(value = "Start/stop a JVM or take a heap dump",
             response = String.class
     )
-    @ApiResponses(@ApiResponse(code = 500, message = "Jvm operation unsuccessful"))
-    Response controlJvm(@ApiParam(value = "The ID of the jvm", required = true) @PathParam("jvmId") final Identifier<Jvm> aJvmId,
+    @ApiResponses(@ApiResponse(code = 500, message = "JVM operation unsuccessful"))
+    Response controlJvm(@ApiParam(value = "The ID of the JVM", required = true) @PathParam("jvmId") final Identifier<Jvm> aJvmId,
                         @ApiParam(value = "The control operation to execute", required = true) final JsonControlJvm aJvmToControl,
                         @ApiParam(value = "If set to true then block the thread until the control operation returns", required = true) @QueryParam("wait") Boolean wait,
                         @ApiParam(value = "When 'wait=true' set a maximum time to block the thread", required = true) @QueryParam("timeout") Long waitTimeout,
@@ -89,8 +89,8 @@ public interface JvmServiceRest {
     @ApiOperation(value = "Generates and deploy all JVM resource files",
             response = Jvm.class
     )
-    @ApiResponses(@ApiResponse(code = 500, message = "Remote generation of jvm failed"))
-    Response generateAndDeployJvm(@ApiParam(value = "The name of the jvm to generated", required = true) @PathParam("jvmName") final String jvmName,
+    @ApiResponses(@ApiResponse(code = 500, message = "Remote generation of JVM failed"))
+    Response generateAndDeployJvm(@ApiParam(value = "The name of the JVM to generated", required = true) @PathParam("jvmName") final String jvmName,
                                   @BeanParam final AuthenticatedUser aUser);
 
     /**
@@ -105,8 +105,8 @@ public interface JvmServiceRest {
     @ApiOperation(value = "Generates and deploy a single JVM resource file as specified by the fileName",
             response = Jvm.class
     )
-    @ApiResponses(@ApiResponse(code = 500, message = "Failed to deploy jvm resource"))
-    Response generateAndDeployFile(@ApiParam(value = "The name of the jvm associated with the resource", required = true) @PathParam("jvmName") final String jvmName,
+    @ApiResponses(@ApiResponse(code = 500, message = "Failed to deploy JVM resource"))
+    Response generateAndDeployFile(@ApiParam(value = "The name of the JVM associated with the resource", required = true) @PathParam("jvmName") final String jvmName,
                                    @ApiParam(value = "The name of the resource to be generated and deployed", required = true) @PathParam("fileName") final String fileName,
                                    @BeanParam final AuthenticatedUser aUser);
 
@@ -120,14 +120,14 @@ public interface JvmServiceRest {
     @ApiOperation(value = "Initiate a heartbeat followed by an SSH check",
             response = String.class
     )
-    Response diagnoseJvm(@ApiParam(value = "The id of the jvm whose state needs to be diagnosed", required = true) @PathParam("jvmId") final Identifier<Jvm> aJvmId, @BeanParam final AuthenticatedUser aUser);
+    Response diagnoseJvm(@ApiParam(value = "The id of the JVM whose state needs to be diagnosed", required = true) @PathParam("jvmId") final Identifier<Jvm> aJvmId, @BeanParam final AuthenticatedUser aUser);
 
     @GET
     @Path("/{jvmName}/resources/name")
-    @ApiOperation(value = "Get all the resources corresponding to a specific jvm",
+    @ApiOperation(value = "Get all the resources corresponding to a specific JVM",
             response = List.class
     )
-    Response getResourceNames(@ApiParam(value = "The name of the jvm for which corresponding all resources are to be obtained", required = true) @PathParam("jvmName") final String jvmName);
+    Response getResourceNames(@ApiParam(value = "The name of the JVM for which corresponding all resources are to be obtained", required = true) @PathParam("jvmName") final String jvmName);
 
     /**
      * Get resource template content.
@@ -138,22 +138,22 @@ public interface JvmServiceRest {
      */
     @GET
     @Path("/{jvmName}/resources/template/{resourceTemplateName}")
-    @ApiOperation(value = "Get the template of a file for the given jvm and file name",
+    @ApiOperation(value = "Get the template of a file for the given JVM and file name",
             response = String.class
     )
-    Response getResourceTemplate(@ApiParam(value = "The name of the jvm", required = true) @PathParam("jvmName") final String jvmName,
+    Response getResourceTemplate(@ApiParam(value = "The name of the JVM", required = true) @PathParam("jvmName") final String jvmName,
                                  @ApiParam(value = "The name of the resource", required = true) @PathParam("resourceTemplateName") final String resourceTemplateName,
                                  @ApiParam(value = "If true then return the generated template, else return the raw template", required = true) @QueryParam("tokensReplaced") final boolean tokensReplaced);
 
     @PUT
     @Path("/{jvmName}/resources/template/{resourceTemplateName}")
     @Consumes(MediaType.TEXT_PLAIN)
-    @ApiOperation(value = "Update an existing jvm template with the new content provided",
+    @ApiOperation(value = "Update an existing JVM template with the new content provided",
             response = String.class
     )
     @ApiResponses(@ApiResponse(code = 500, message = "Failed to update the template"))
         // TODO: Pass authenticated user.
-    Response updateResourceTemplate(@ApiParam(value = "The name of the jvm", required = true) @PathParam("jvmName") final String jvmName,
+    Response updateResourceTemplate(@ApiParam(value = "The name of the JVM", required = true) @PathParam("jvmName") final String jvmName,
                                     @ApiParam(value = "The name of the resource", required = true) @PathParam("resourceTemplateName") final String resourceTemplateName,
                                     @ApiParam(value = "The new content of the resource", required = true) final String content);
 
@@ -167,13 +167,13 @@ public interface JvmServiceRest {
     @PUT
     @Path("/{jvmName}/resources/preview/{resourceTemplateName}")
     @Consumes(MediaType.TEXT_PLAIN)
-    @ApiOperation(value = "View the contents of a jvm resource file",
+    @ApiOperation(value = "View the contents of a JVM resource file",
             response = String.class
     )
     @ApiResponses(@ApiResponse(code = 500, message = "Error previewing template"))
-    Response previewResourceTemplate(@ApiParam(value = "The name of the jvm", required = true) @PathParam("jvmName") String jvmName,
+    Response previewResourceTemplate(@ApiParam(value = "The name of the JVM", required = true) @PathParam("jvmName") String jvmName,
                                      @ApiParam(value = "The name of the resource to preview", required = true) @PathParam("resourceTemplateName") final String resourceTemplateName,
-                                     @ApiParam(value = "The name of the jvm's group", required = true) @MatrixParam("groupName") String groupName,
+                                     @ApiParam(value = "The name of the JVM's group", required = true) @MatrixParam("groupName") String groupName,
                                      @ApiParam(value = "The content to be generated", required = true) String template);
 
 }

--- a/jwala-webservices/src/main/java/com/cerner/jwala/ws/rest/v1/service/jvm/JvmServiceRest.java
+++ b/jwala-webservices/src/main/java/com/cerner/jwala/ws/rest/v1/service/jvm/JvmServiceRest.java
@@ -6,33 +6,56 @@ import com.cerner.jwala.ws.rest.v1.provider.AuthenticatedUser;
 import com.cerner.jwala.ws.rest.v1.service.jvm.impl.JsonControlJvm;
 import com.cerner.jwala.ws.rest.v1.service.jvm.impl.JsonCreateJvm;
 import com.cerner.jwala.ws.rest.v1.service.jvm.impl.JsonUpdateJvm;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
 
 import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import java.util.List;
 
+@Api(value = "/jvms", tags = "jvms")
 @Path("/jvms")
 @Produces(MediaType.APPLICATION_JSON)
 public interface JvmServiceRest {
 
     @GET
+    @ApiOperation(value = "Get all the jvms",
+            response = List.class
+    )
     Response getJvms();
 
     @GET
     @Path("/{jvmId}")
+    @ApiOperation(value = "Get a single jvm by ID",
+            response = Jvm.class
+    )
     Response getJvm(@PathParam("jvmId") final Identifier<Jvm> aJvmId);
 
     @POST
     @Consumes(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = "Create a jvm",
+            response = Jvm.class
+    )
+    @ApiResponses(@ApiResponse(code = 500, message = "Jvm already exists"))
     Response createJvm(JsonCreateJvm jsonCreateJvm, @BeanParam AuthenticatedUser aUser);
 
     @PUT
     @Consumes(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = "Update an existing jvm",
+            response = Jvm.class
+    )
     Response updateJvm(JsonUpdateJvm aJvmToUpdate, @QueryParam("updateJvmPassword") boolean updateJvmPassword,
                        @BeanParam AuthenticatedUser aUser);
 
     @DELETE
     @Path("/{jvmId}")
+    @ApiOperation(value = "Delete an existing jvm",
+            response = Response.class
+    )
+    @ApiResponses(@ApiResponse(code = 500, message = "Unable to delete jvm"))
     Response deleteJvm(@PathParam("jvmId") Identifier<Jvm> id, @QueryParam("hardDelete") boolean hardDelete,
                        @BeanParam final AuthenticatedUser user);
 
@@ -47,6 +70,10 @@ public interface JvmServiceRest {
      */
     @POST
     @Path("/{jvmId}/commands")
+    @ApiOperation(value = "Start/stop a jvm or take a heap dump",
+            response = String.class
+    )
+    @ApiResponses(@ApiResponse(code = 500, message = "Jvm operation unsuccessful"))
     Response controlJvm(@PathParam("jvmId") final Identifier<Jvm> aJvmId,
                         final JsonControlJvm aJvmToControl,
                         @QueryParam("wait") Boolean wait,
@@ -61,6 +88,9 @@ public interface JvmServiceRest {
      */
     @PUT
     @Path("/{jvmName}/conf")
+    @ApiOperation(value = "Generates and deploy all JVM resource files",
+            response = Jvm.class
+    )
     Response generateAndDeployJvm(@PathParam("jvmName") final String jvmName,
                                   @BeanParam final AuthenticatedUser aUser);
 
@@ -73,10 +103,13 @@ public interface JvmServiceRest {
      */
     @PUT
     @Path("/{jvmName}/conf/{fileName}")
+    @ApiOperation(value = "Generates and deploy a single JVM resource file as specified by the fileName",
+            response = Jvm.class
+    )
     Response generateAndDeployFile(@PathParam("jvmName") final String jvmName,
                                    @PathParam("fileName") final String fileName,
                                    @BeanParam final AuthenticatedUser aUser);
-    
+
     /**
      * Initiate a heartbeat followed by an SSH check
      * @param aJvmId id of the jvm to diagnose
@@ -84,10 +117,16 @@ public interface JvmServiceRest {
      */
     @GET
     @Path("/{jvmId}/diagnosis")
+    @ApiOperation(value = "Initiate a heartbeat followed by an SSH check",
+            response = String.class
+    )
     Response diagnoseJvm(@PathParam("jvmId") final Identifier<Jvm> aJvmId, @BeanParam final AuthenticatedUser aUser);
 
     @GET
     @Path("/{jvmName}/resources/name")
+    @ApiOperation(value = "Get all the resources corresponding to a specific jvm",
+            response = List.class
+    )
     Response getResourceNames(@PathParam("jvmName") final String jvmName);
 
     /**
@@ -99,6 +138,9 @@ public interface JvmServiceRest {
      */
     @GET
     @Path("/{jvmName}/resources/template/{resourceTemplateName}")
+    @ApiOperation(value = "Get the template of a file for the given jvm and file name",
+            response = String.class
+    )
     Response getResourceTemplate(@PathParam("jvmName") final String jvmName,
                                  @PathParam("resourceTemplateName") final String resourceTemplateName,
                                  @QueryParam("tokensReplaced") final boolean tokensReplaced);
@@ -106,7 +148,10 @@ public interface JvmServiceRest {
     @PUT
     @Path("/{jvmName}/resources/template/{resourceTemplateName}")
     @Consumes(MediaType.TEXT_PLAIN)
-    // TODO: Pass authenticated user.
+    @ApiOperation(value = "Update an existing jvm template with the new content provided",
+            response = String.class
+    )
+        // TODO: Pass authenticated user.
     Response updateResourceTemplate(@PathParam("jvmName") final String jvmName,
                                     @PathParam("resourceTemplateName") final String resourceTemplateName,
                                     final String content);
@@ -121,6 +166,9 @@ public interface JvmServiceRest {
     @PUT
     @Path("/{jvmName}/resources/preview/{resourceTemplateName}")
     @Consumes(MediaType.TEXT_PLAIN)
+    @ApiOperation(value = "View the contents of a jvm resource file",
+            response = String.class
+    )
     Response previewResourceTemplate(@PathParam("jvmName") String jvmName,
                                      @PathParam("resourceTemplateName") final String resourceTemplateName,
                                      @MatrixParam("groupName") String groupName,

--- a/jwala-webservices/src/main/java/com/cerner/jwala/ws/rest/v1/service/jvm/JvmServiceRest.java
+++ b/jwala-webservices/src/main/java/com/cerner/jwala/ws/rest/v1/service/jvm/JvmServiceRest.java
@@ -37,7 +37,8 @@ public interface JvmServiceRest {
             response = Jvm.class
     )
     @ApiResponses(@ApiResponse(code = 500, message = "JVM already exists"))
-    Response createJvm(@ApiParam(value = "The configuration info for the JVM to be created", required = true) JsonCreateJvm jsonCreateJvm, @BeanParam AuthenticatedUser aUser);
+    Response createJvm(@ApiParam(value = "The configuration info for the JVM to be created", required = true) JsonCreateJvm jsonCreateJvm,
+                       @ApiParam(value = "The authentication details of user") @BeanParam AuthenticatedUser aUser);
 
     @PUT
     @Consumes(MediaType.APPLICATION_JSON)
@@ -45,8 +46,8 @@ public interface JvmServiceRest {
             response = Jvm.class
     )
     @ApiResponses(@ApiResponse(code = 500, message = "Failed to update the JVM"))
-    Response updateJvm(@ApiParam(value = "The configuration info for the JVM to be updated", required = true) JsonUpdateJvm aJvmToUpdate, @QueryParam("updateJvmPassword") boolean updateJvmPassword,
-                       @BeanParam AuthenticatedUser aUser);
+    Response updateJvm(@ApiParam(value = "The configuration info for the JVM to be updated", required = true) JsonUpdateJvm aJvmToUpdate, @ApiParam(value = "If set to true then update jvm password") @QueryParam("updateJvmPassword") boolean updateJvmPassword,
+                       @ApiParam(value = "The user authentication details") @BeanParam AuthenticatedUser aUser);
 
     @DELETE
     @Path("/{jvmId}")
@@ -55,7 +56,7 @@ public interface JvmServiceRest {
     )
     @ApiResponses(@ApiResponse(code = 500, message = "Unable to delete JVM"))
     Response deleteJvm(@ApiParam(value = "The ID of the JVM to be deleted", required = true) @PathParam("jvmId") Identifier<Jvm> id, @ApiParam(value = "Deletes the JVM and its service when set to true; only deletes the JVM when false", required = true) @QueryParam("hardDelete") boolean hardDelete,
-                       @BeanParam final AuthenticatedUser user);
+                       @ApiParam(value = "The authentication details of user") @BeanParam final AuthenticatedUser user);
 
     /**
      * Control a JVM (e.g. start, stop)
@@ -76,7 +77,7 @@ public interface JvmServiceRest {
                         @ApiParam(value = "The control operation to execute", required = true) final JsonControlJvm aJvmToControl,
                         @ApiParam(value = "If set to true then block the thread until the control operation returns", required = true) @QueryParam("wait") Boolean wait,
                         @ApiParam(value = "When 'wait=true' set a maximum time to block the thread", required = true) @QueryParam("timeout") Long waitTimeout,
-                        @BeanParam final AuthenticatedUser aUser);
+                        @ApiParam(value = "The authentication details of user") @BeanParam final AuthenticatedUser aUser);
 
     /**
      * Generate JVM config files then deploy the JVM.
@@ -91,7 +92,7 @@ public interface JvmServiceRest {
     )
     @ApiResponses(@ApiResponse(code = 500, message = "Remote generation of JVM failed"))
     Response generateAndDeployJvm(@ApiParam(value = "The name of the JVM to generated", required = true) @PathParam("jvmName") final String jvmName,
-                                  @BeanParam final AuthenticatedUser aUser);
+                                  @ApiParam(value = "The authentication details of user") @BeanParam final AuthenticatedUser aUser);
 
     /**
      * Generates and deploy a single JVM resource file as specified by the fileName I presume...have to confirm
@@ -108,7 +109,7 @@ public interface JvmServiceRest {
     @ApiResponses(@ApiResponse(code = 500, message = "Failed to deploy JVM resource"))
     Response generateAndDeployFile(@ApiParam(value = "The name of the JVM associated with the resource", required = true) @PathParam("jvmName") final String jvmName,
                                    @ApiParam(value = "The name of the resource to be generated and deployed", required = true) @PathParam("fileName") final String fileName,
-                                   @BeanParam final AuthenticatedUser aUser);
+                                   @ApiParam(value = "The authentication details of user") @BeanParam final AuthenticatedUser aUser);
 
     /**
      * Initiate a heartbeat followed by an SSH check
@@ -120,7 +121,8 @@ public interface JvmServiceRest {
     @ApiOperation(value = "Initiate a heartbeat followed by an SSH check",
             response = String.class
     )
-    Response diagnoseJvm(@ApiParam(value = "The id of the JVM whose state needs to be diagnosed", required = true) @PathParam("jvmId") final Identifier<Jvm> aJvmId, @BeanParam final AuthenticatedUser aUser);
+    Response diagnoseJvm(@ApiParam(value = "The id of the JVM whose state needs to be diagnosed", required = true) @PathParam("jvmId") final Identifier<Jvm> aJvmId,
+                         @ApiParam(value = "The authentication details of user") @BeanParam final AuthenticatedUser aUser);
 
     @GET
     @Path("/{jvmName}/resources/name")

--- a/jwala-webservices/src/main/java/com/cerner/jwala/ws/rest/v1/service/jvm/impl/JvmServiceRestImpl.java
+++ b/jwala-webservices/src/main/java/com/cerner/jwala/ws/rest/v1/service/jvm/impl/JvmServiceRestImpl.java
@@ -1,17 +1,5 @@
 package com.cerner.jwala.ws.rest.v1.service.jvm.impl;
 
-import java.util.ArrayList;
-import java.util.List;
-
-import javax.persistence.EntityExistsException;
-import javax.ws.rs.core.Context;
-import javax.ws.rs.core.Response;
-
-import com.cerner.jwala.common.request.jvm.ControlJvmRequestFactory;
-import org.apache.cxf.jaxrs.ext.MessageContext;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.cerner.jwala.common.domain.model.fault.FaultType;
 import com.cerner.jwala.common.domain.model.id.Identifier;
 import com.cerner.jwala.common.domain.model.jvm.Jvm;
@@ -21,12 +9,22 @@ import com.cerner.jwala.common.exception.InternalErrorException;
 import com.cerner.jwala.common.exec.CommandOutput;
 import com.cerner.jwala.common.exec.CommandOutputReturnCode;
 import com.cerner.jwala.common.request.jvm.ControlJvmRequest;
+import com.cerner.jwala.common.request.jvm.ControlJvmRequestFactory;
 import com.cerner.jwala.service.jvm.JvmControlService;
 import com.cerner.jwala.service.jvm.JvmService;
 import com.cerner.jwala.service.jvm.exception.JvmControlServiceException;
 import com.cerner.jwala.ws.rest.v1.provider.AuthenticatedUser;
 import com.cerner.jwala.ws.rest.v1.response.ResponseBuilder;
 import com.cerner.jwala.ws.rest.v1.service.jvm.JvmServiceRest;
+import org.apache.cxf.jaxrs.ext.MessageContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.persistence.EntityExistsException;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.Response;
+import java.util.ArrayList;
+import java.util.List;
 
 public class JvmServiceRestImpl implements JvmServiceRest {
 

--- a/jwala-webservices/src/main/java/com/cerner/jwala/ws/rest/v1/service/media/MediaServiceRest.java
+++ b/jwala-webservices/src/main/java/com/cerner/jwala/ws/rest/v1/service/media/MediaServiceRest.java
@@ -1,7 +1,9 @@
 package com.cerner.jwala.ws.rest.v1.service.media;
 
+import com.cerner.jwala.common.domain.model.app.Application;
 import com.cerner.jwala.persistence.jpa.domain.JpaMedia;
 import com.cerner.jwala.ws.rest.v1.provider.AuthenticatedUser;
+import io.swagger.annotations.*;
 import org.apache.cxf.jaxrs.ext.multipart.Attachment;
 
 import javax.ws.rs.*;
@@ -12,27 +14,48 @@ import java.util.List;
 /**
  * The REST service contract
  */
+@Api(value = "/media", tags = "media")
 @Path("/media")
 @Produces(MediaType.APPLICATION_JSON)
 public interface MediaServiceRest {
 
     @POST
     @Consumes(MediaType.MULTIPART_FORM_DATA)
-    Response createMedia(final List<Attachment> attachments);
+    @ApiOperation(value = "Create a media to be used by the JVMs and Web Servers",
+            response = JpaMedia.class
+    )
+    @ApiResponses(@ApiResponse(code = 500, message = "Failed to retrieve attachments"))
+    Response createMedia(@ApiParam(value = "The media binary and deployment attributes", required = true) final List<Attachment> attachments);
 
     @PUT
     @Consumes(MediaType.APPLICATION_JSON)
-    Response updateMedia(JpaMedia media, @BeanParam AuthenticatedUser aUser);
+    @ApiOperation(value = "Update an existing media",
+            response = JpaMedia.class
+    )
+    Response updateMedia(@ApiParam(value = "The media to be updated", required = true) JpaMedia media, @BeanParam AuthenticatedUser aUser);
 
     @DELETE
     @Path("/{mediaName}/{mediaType}")
-    Response removeMedia(@PathParam("mediaName") String name, @PathParam("mediaType") String type, @BeanParam AuthenticatedUser aUser);
+    @ApiOperation(value = "Delete a media entry",
+            response = Response.class
+    )
+    @ApiResponses(@ApiResponse(code = 500, message = "Failed to retrieve attachments"))
+    Response removeMedia(@ApiParam(value = "The name of the media to be deleted", required = true) @PathParam("mediaName") String name,
+                         @ApiParam(value = "The type of the media to be deleted", required = true) @PathParam("mediaType") String type, @BeanParam AuthenticatedUser aUser);
 
     @GET
-    Response getMedia(@MatrixParam("id") Long id, @MatrixParam("name") String mediaName, @BeanParam AuthenticatedUser aUser);
+    @ApiOperation(value = "Get a media entry by its name or ID",
+            notes = "When no ID is specified the name attribute is used, if no name attribute is specified either then all of the media entries are returned",
+            response = JpaMedia.class
+    )
+    Response getMedia(@ApiParam(value = "The ID of the media") @MatrixParam("id") Long id,
+                      @ApiParam(value = "The name of the media") @MatrixParam("name") String mediaName, @BeanParam AuthenticatedUser aUser);
 
     @GET
     @Path("/types")
+    @ApiOperation(value = "Get all of the media types currently configured",
+            response = JpaMedia.class
+    )
     Response getMediaTypes();
 
 }

--- a/jwala-webservices/src/main/java/com/cerner/jwala/ws/rest/v1/service/resource/ResourceServiceRest.java
+++ b/jwala-webservices/src/main/java/com/cerner/jwala/ws/rest/v1/service/resource/ResourceServiceRest.java
@@ -1,5 +1,6 @@
 package com.cerner.jwala.ws.rest.v1.service.resource;
 
+import com.cerner.jwala.common.domain.model.resource.ResourceContent;
 import com.cerner.jwala.common.domain.model.resource.ResourceGroup;
 import com.cerner.jwala.persistence.jpa.domain.JpaMedia;
 import com.cerner.jwala.service.resource.impl.CreateResourceResponseWrapper;
@@ -12,6 +13,7 @@ import com.cerner.jwala.ws.rest.v1.provider.AuthenticatedUser;
 import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import java.io.File;
 import java.util.List;
 import java.util.Map;
 
@@ -132,8 +134,8 @@ public interface ResourceServiceRest extends InitializingBean {
     @DELETE
     @Path("/template/{name}")
     @Deprecated
-    @ApiOperation(value = "Delete a resouce",
-            notes = "DEPRECATED METHOD",
+    @ApiOperation(value = "Delete a resource",
+            notes = "DEPRECATED METHOD. Use the /templates API for deleting resources.",
             response = Integer.class
     )
     @ApiResponses(@ApiResponse(code = 500, message = "Resource not found"))
@@ -151,7 +153,14 @@ public interface ResourceServiceRest extends InitializingBean {
      */
     @DELETE
     @Path("/templates")
-    Response deleteResources(@MatrixParam("name") String[] templateNameArray, @MatrixParam("") ResourceHierarchyParam resourceHierarchyParam, @BeanParam AuthenticatedUser user);
+    @ApiOperation(value = "Delete a resource or mulitple resources",
+            notes = "This is the preferred method for deleting resources",
+            response = Integer.class
+    )
+    @ApiResponses(@ApiResponse(code = 500, message = "Resource not found"))
+    Response deleteResources(@ApiParam(value = "The list of the name of the resources to be deleted", required = true) @MatrixParam("name") String[] templateNameArray,
+                             @ApiParam(value = "The parameters that identify the entity associated with the resource to be deleted", required = true) @MatrixParam("") ResourceHierarchyParam resourceHierarchyParam,
+                             @BeanParam AuthenticatedUser user);
 
     /**
      * Get the template content
@@ -162,7 +171,11 @@ public interface ResourceServiceRest extends InitializingBean {
      */
     @GET
     @Path("/{resourceName}/content")
-    Response getResourceContent(@PathParam("resourceName") String resourceName, @MatrixParam("") ResourceHierarchyParam resourceHierarchyParam);
+    @ApiOperation(value = "Get the template content",
+            response = ResourceContent.class
+    )
+    Response getResourceContent(@ApiParam(value = "The name of the resource", required = true) @PathParam("resourceName") String resourceName,
+                                @ApiParam(value = "The parameters that identify the entity associated with the resource", required = true) @MatrixParam("") ResourceHierarchyParam resourceHierarchyParam);
 
     /**
      * Update the template content
@@ -174,7 +187,12 @@ public interface ResourceServiceRest extends InitializingBean {
     @PUT
     @Path("/template/{resourceName}")
     @Consumes(MediaType.TEXT_PLAIN)
-    Response updateResourceContent(@PathParam("resourceName") String resourceName, @MatrixParam("") ResourceHierarchyParam resourceHierarchyParam, final String content);
+    @ApiOperation(value = "Update the template content",
+            response = String.class
+    )
+    Response updateResourceContent(@ApiParam(value = "The name of the resource to be updated", required = true) @PathParam("resourceName") String resourceName,
+                                   @ApiParam(value = "The parameters that identify the entity associated with the resource", required = true) @MatrixParam("") ResourceHierarchyParam resourceHierarchyParam,
+                                   @ApiParam(value = "The new resource content", required = true) final String content);
 
     /**
      * Update the template meta data
@@ -186,7 +204,13 @@ public interface ResourceServiceRest extends InitializingBean {
     @PUT
     @Path("/template/metadata/{resourceName}")
     @Consumes(MediaType.TEXT_PLAIN)
-    Response updateResourceMetaData(@PathParam("resourceName") String resourceName, @MatrixParam("") ResourceHierarchyParam resourceHierarchyParam, final String metaData);
+    @ApiOperation(value = "Update the template meta data",
+            response = String.class
+    )
+    @ApiResponses(@ApiResponse(code = 500, message = "Failed to update the meta data"))
+    Response updateResourceMetaData(@ApiParam(value = "The name of the resource to be updated", required = true) @PathParam("resourceName") String resourceName,
+                                    @ApiParam(value = "The parameters that identify the entity associated with the resource", required = true) @MatrixParam("") ResourceHierarchyParam resourceHierarchyParam,
+                                    @ApiParam(value = "The new meta data", required = true) final String metaData);
 
     /**
      * Preview the template content
@@ -197,7 +221,12 @@ public interface ResourceServiceRest extends InitializingBean {
     @PUT
     @Path("/template/preview/{resourceName}")
     @Consumes(MediaType.TEXT_PLAIN)
-    Response previewResourceContent(@PathParam("resourceName") String resourceName, @MatrixParam("") ResourceHierarchyParam resourceHierarchyParam, final String content);
+    @ApiOperation(value = "Preview the template content",
+            response = String.class
+    )
+    Response previewResourceContent(@ApiParam(value = "The name of the resource to be updated", required = true) @PathParam("resourceName") String resourceName,
+                                    @ApiParam(value = "The parameters that identify the entity associated with the resource", required = true) @MatrixParam("") ResourceHierarchyParam resourceHierarchyParam,
+                                    @ApiParam(value = "The content to be previewed", required = true) final String content);
 
     /**
      * Get the key/value pairings for any external properties that were loaded
@@ -208,6 +237,9 @@ public interface ResourceServiceRest extends InitializingBean {
     @Path("/properties")
     // TODO return mime type text/plain
 //    @Produces(MediaType.TEXT_PLAIN)
+    @ApiOperation(value = "Get the key/value pairings for any external properties that were loaded",
+            response = Map.class
+    )
     Response getExternalProperties();
 
     /**
@@ -218,11 +250,17 @@ public interface ResourceServiceRest extends InitializingBean {
     @GET
     @Path("/properties/download")
     @Produces(MediaType.APPLICATION_OCTET_STREAM)
+    @ApiOperation(value = "Return the external properties file as a download",
+            response = File.class
+    )
     Response getExternalPropertiesDownload();
 
     @GET
     @Path("/properties/view")
     @Produces(MediaType.TEXT_PLAIN)
+    @ApiOperation(value = "Return the external properties as a string",
+            response = String.class
+    )
     Response getExternalPropertiesView();
 
     /**
@@ -233,6 +271,10 @@ public interface ResourceServiceRest extends InitializingBean {
     @POST
     @Path("/properties")
     @Consumes(MediaType.MULTIPART_FORM_DATA)
+    @ApiOperation(value = "Upload the external properties file",
+            response = CreateResourceResponseWrapper.class
+    )
+    @ApiResponses(@ApiResponse(code = 500, message = "File exceptions thrown while attempting to upload external properties file"))
     Response uploadExternalProperties(@BeanParam AuthenticatedUser user);
 
     /**
@@ -242,6 +284,9 @@ public interface ResourceServiceRest extends InitializingBean {
      */
     @GET
     @Path("templates/names")
-    Response getResourcesFileNames(@MatrixParam("") final ResourceHierarchyParam resourceHierarchyParam);
+    @ApiOperation(value = "Get the name of any templates that were loaded for a resource",
+            response = String.class
+    )
+    Response getResourcesFileNames(@ApiParam(value = "The parameters that identify the entity associated with the resource", required = true) @MatrixParam("") final ResourceHierarchyParam resourceHierarchyParam);
 
 }

--- a/jwala-webservices/src/main/java/com/cerner/jwala/ws/rest/v1/service/resource/ResourceServiceRest.java
+++ b/jwala-webservices/src/main/java/com/cerner/jwala/ws/rest/v1/service/resource/ResourceServiceRest.java
@@ -2,13 +2,11 @@ package com.cerner.jwala.ws.rest.v1.service.resource;
 
 import com.cerner.jwala.common.domain.model.resource.ResourceContent;
 import com.cerner.jwala.common.domain.model.resource.ResourceGroup;
-import com.cerner.jwala.persistence.jpa.domain.JpaMedia;
 import com.cerner.jwala.service.resource.impl.CreateResourceResponseWrapper;
+import com.cerner.jwala.ws.rest.v1.provider.AuthenticatedUser;
 import io.swagger.annotations.*;
 import org.apache.cxf.jaxrs.ext.multipart.Attachment;
 import org.springframework.beans.factory.InitializingBean;
-
-import com.cerner.jwala.ws.rest.v1.provider.AuthenticatedUser;
 
 import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
@@ -46,7 +44,7 @@ public interface ResourceServiceRest extends InitializingBean {
     @ApiResponses(@ApiResponse(code = 500, message = "Invalid number of attachments"))
     Response createTemplate(@ApiParam(value = "The list of attachments  including the template and the meta data file", required = true) List<Attachment> attachments,
                             @ApiParam(value = "The target entity associated with the template resource", required = true) @PathParam("targetName") final String targetName,
-                            @BeanParam AuthenticatedUser user);
+                            @ApiParam(value = "The authentication details of user") @BeanParam AuthenticatedUser user);
 
     @GET
     @Path("/data")
@@ -141,7 +139,7 @@ public interface ResourceServiceRest extends InitializingBean {
     @ApiResponses(@ApiResponse(code = 500, message = "Resource not found"))
     Response deleteResource(@ApiParam(value = "The name of the resource to be deleted", required = true) @PathParam("name") String templateName,
                             @ApiParam(value = "The target entity associated with the resource to be deleted", required = true) @MatrixParam("") ResourceHierarchyParam resourceHierarchyParam,
-                            @BeanParam AuthenticatedUser user);
+                            @ApiParam(value = "The authentication details of user") @BeanParam AuthenticatedUser user);
 
     /**
      * Delete resources.
@@ -160,7 +158,7 @@ public interface ResourceServiceRest extends InitializingBean {
     @ApiResponses(@ApiResponse(code = 500, message = "Resource not found"))
     Response deleteResources(@ApiParam(value = "The list of the name of the resources to be deleted", required = true) @MatrixParam("name") String[] templateNameArray,
                              @ApiParam(value = "The parameters that identify the entity associated with the resource to be deleted", required = true) @MatrixParam("") ResourceHierarchyParam resourceHierarchyParam,
-                             @BeanParam AuthenticatedUser user);
+                             @ApiParam(value = "The authentication details of user") @BeanParam AuthenticatedUser user);
 
     /**
      * Get the template content
@@ -275,7 +273,7 @@ public interface ResourceServiceRest extends InitializingBean {
             response = CreateResourceResponseWrapper.class
     )
     @ApiResponses(@ApiResponse(code = 500, message = "File exceptions thrown while attempting to upload external properties file"))
-    Response uploadExternalProperties(@BeanParam AuthenticatedUser user);
+    Response uploadExternalProperties(@ApiParam(value = "The authentication details of user") @BeanParam AuthenticatedUser user);
 
     /**
      * Get the name of any templates that were loaded for a resource

--- a/jwala-webservices/src/main/java/com/cerner/jwala/ws/rest/v1/service/user/UserServiceRest.java
+++ b/jwala-webservices/src/main/java/com/cerner/jwala/ws/rest/v1/service/user/UserServiceRest.java
@@ -1,36 +1,42 @@
 package com.cerner.jwala.ws.rest.v1.service.user;
 
+import io.swagger.annotations.*;
+
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import javax.ws.rs.FormParam;
-import javax.ws.rs.GET;
-import javax.ws.rs.POST;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
+import javax.ws.rs.*;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
-import org.springframework.security.access.annotation.Secured;
-import org.springframework.security.access.prepost.PreAuthorize;
-
+@Api(value = "/user", tags = "user")
 @Path("/user")
 @Produces(MediaType.APPLICATION_JSON)
 public interface UserServiceRest {
 
     @POST
     @Path("/login")
+    @ApiOperation(value = "Login to the application",
+            response = Response.class
+    )
+    @ApiResponses(@ApiResponse(code = 500, message = "Error login"))
     Response login(@Context HttpServletRequest request,
-                   @FormParam("userName") String userName,
-                   @FormParam("password") String password);
+                   @ApiParam(value = "The user", required = true) @FormParam("userName") String userName,
+                   @ApiParam(value = "The user's password", required = true) @FormParam("password") String password);
 
     @POST
     @Path("/logout")
-    Response logout(@Context HttpServletRequest request, 
+    @ApiOperation(value = "Logout from the application",
+            response = Response.class
+    )
+    Response logout(@Context HttpServletRequest request,
                     @Context HttpServletResponse response);
     
     @GET
     @Path("/isUserAdmin")
-    Response isUserAdmin(@Context HttpServletRequest request, 
+    @ApiOperation(value = "Checks if the current logged on user is an administrator for the application",
+            response = String.class
+    )
+    Response isUserAdmin(@Context HttpServletRequest request,
                          @Context HttpServletResponse response);
 }

--- a/jwala-webservices/src/main/java/com/cerner/jwala/ws/rest/v1/service/user/UserServiceRest.java
+++ b/jwala-webservices/src/main/java/com/cerner/jwala/ws/rest/v1/service/user/UserServiceRest.java
@@ -19,7 +19,7 @@ public interface UserServiceRest {
     @ApiOperation(value = "Login to the application",
             response = Response.class
     )
-    @ApiResponses(@ApiResponse(code = 500, message = "Error login"))
+    @ApiResponses(@ApiResponse(code = 401, message = "Error login"))
     Response login(@Context HttpServletRequest request,
                    @ApiParam(value = "The user", required = true) @FormParam("userName") String userName,
                    @ApiParam(value = "The user's password", required = true) @FormParam("password") String password);

--- a/jwala-webservices/src/main/java/com/cerner/jwala/ws/rest/v1/service/webserver/WebServerServiceRest.java
+++ b/jwala-webservices/src/main/java/com/cerner/jwala/ws/rest/v1/service/webserver/WebServerServiceRest.java
@@ -3,69 +3,114 @@ package com.cerner.jwala.ws.rest.v1.service.webserver;
 import com.cerner.jwala.common.domain.model.group.Group;
 import com.cerner.jwala.common.domain.model.id.Identifier;
 import com.cerner.jwala.common.domain.model.webserver.WebServer;
+import com.cerner.jwala.common.exec.CommandOutput;
 import com.cerner.jwala.ws.rest.v1.provider.AuthenticatedUser;
 import com.cerner.jwala.ws.rest.v1.service.webserver.impl.JsonControlWebServer;
 import com.cerner.jwala.ws.rest.v1.service.webserver.impl.JsonCreateWebServer;
 import com.cerner.jwala.ws.rest.v1.service.webserver.impl.JsonUpdateWebServer;
+import io.swagger.annotations.*;
 
 import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
+@Api(value = "/webservers", tags = "webservers")
 @Path("/webservers")
 @Produces(MediaType.APPLICATION_JSON)
 public interface WebServerServiceRest {
 
     @GET
-    Response getWebServers(@QueryParam("groupId") final Identifier<Group> aGroupId);
+    @Consumes(MediaType.MULTIPART_FORM_DATA)
+    @ApiOperation(value = "Get all the web servers in a group",
+            response = WebServer.class
+    )
+    Response getWebServers(@ApiParam(value = "The web servers' group ID", required = true) @QueryParam("groupId") final Identifier<Group> aGroupId);
 
     @GET
     @Path("/{webserverId}")
-    Response getWebServer(@PathParam("webserverId") final Identifier<WebServer> aWebServerId);
+    @ApiOperation(value = "Get a single web server by ID",
+            response = WebServer.class
+    )
+    Response getWebServer(@ApiParam(value = "The web server's ID", required = true) @PathParam("webserverId") final Identifier<WebServer> aWebServerId);
 
     @POST
     @Consumes(MediaType.APPLICATION_JSON)
-    Response createWebServer(final JsonCreateWebServer aWebServerToCreate,
+    @ApiOperation(value = "Create a web server",
+            response = WebServer.class
+    )
+    @ApiResponses(@ApiResponse(code = 500, message = "Web Server already exists"))
+    Response createWebServer(@ApiParam(value = "The configuration info for the web server to be created", required = true) final JsonCreateWebServer aWebServerToCreate,
                              @BeanParam final AuthenticatedUser aUser);
 
     @PUT
     @Consumes(MediaType.APPLICATION_JSON)
-    Response updateWebServer(final JsonUpdateWebServer aWebServerToUpdate,
+    @ApiOperation(value = "Update an existing web server",
+            response = WebServer.class
+    )
+    @ApiResponses(@ApiResponse(code = 500, message = "Failed to update the web server"))
+    Response updateWebServer(@ApiParam(value = "The configuration info for the web server to be updated", required = true) final JsonUpdateWebServer aWebServerToUpdate,
                              @BeanParam final AuthenticatedUser aUser);
 
     @DELETE
     @Path("/{webserverId}")
-    Response deleteWebServer(@PathParam("webserverId") final Identifier<WebServer> id, @QueryParam("hardDelete") boolean hardDelete,
+    @ApiOperation(value = "Delete a web server",
+            response = Response.class
+    )
+    Response deleteWebServer(@ApiParam(value = "The ID of the web server to be deleted", required = true) @PathParam("webserverId") final Identifier<WebServer> id,
+                             @ApiParam(value = "Deletes the web server and its service when set to true; only deletes the web server when false", required = true) @QueryParam("hardDelete") boolean hardDelete,
                              @BeanParam final AuthenticatedUser user);
 
     @POST
     @Path("/{webServerId}/commands")
-    Response controlWebServer(@PathParam("webServerId") final Identifier<WebServer> aWebServerId,
-                              final JsonControlWebServer aWebServerToControl,
+    @ApiOperation(value = "Start and stop a web server",
+            response = String.class
+    )
+    @ApiResponses(@ApiResponse(code = 500, message = "Web Server operation unsuccessful"))
+    Response controlWebServer(@ApiParam(value = "The ID of the web server", required = true) @PathParam("webServerId") final Identifier<WebServer> aWebServerId,
+                              @ApiParam(value = "The control operation to execute", required = true) final JsonControlWebServer aWebServerToControl,
                               @BeanParam final AuthenticatedUser aUser,
-                              @QueryParam("wait") final Boolean wait,
-                              @QueryParam("timeout") final Long waitTimeout);
+                              @ApiParam(value = "If set to true then block the thread until the control operation returns", required = true) @QueryParam("wait") final Boolean wait,
+                              @ApiParam(value = "When 'wait=true' set a maximum time to block the thread", required = true) @QueryParam("timeout") final Long waitTimeout);
 
     @GET
     @Path("/{webServerName}/conf")
-    Response generateConfig(@PathParam("webServerName") final String webServerName);
+    @ApiOperation(value = "Generate the httpd.conf for the web server",
+            response = String.class
+    )
+    Response generateConfig(@ApiParam(value = "The name of the web server to generate the httpd.conf", required = true) @PathParam("webServerName") final String webServerName);
 
     @PUT
     @Path("/{webServerName}/conf/{fileName}")
     @Consumes(MediaType.APPLICATION_JSON)
-    Response generateAndDeployConfig(@PathParam("webServerName") final String webServerName, @PathParam("fileName") String fileName,@BeanParam final AuthenticatedUser aUser);
+    @ApiOperation(value = "Generate and deploy a web server resource",
+            response = WebServer.class
+    )
+    Response generateAndDeployConfig(@ApiParam(value = "The name of the web server associated with the resource", required = true) @PathParam("webServerName") final String webServerName,
+                                     @ApiParam(value = "The name of the resource to be generated and deployed", required = true) @PathParam("fileName") String fileName,
+                                     @BeanParam final AuthenticatedUser aUser);
 
     @PUT
     @Path("/{webServerName}/conf/deploy")
-    Response generateAndDeployWebServer(@PathParam("webServerName") final String aWebServerName, @BeanParam final AuthenticatedUser aUser);
+    @ApiOperation(value = "Generate and deploy all of the resources for a web server and create the service",
+            response = WebServer.class
+    )
+    @ApiResponses(@ApiResponse(code = 500, message = "Failed for web server"))
+    Response generateAndDeployWebServer(@ApiParam(value = "The name of the web server to be generated and deployed", required = true) @PathParam("webServerName") final String aWebServerName, @BeanParam final AuthenticatedUser aUser);
 
     @GET
     @Path("/{webServerId}/conf/current")
-    Response getHttpdConfig(@PathParam("webServerId") final Identifier<WebServer> aWebServerId);
+    @ApiOperation(value = "Get the httpd.conf for a web server",
+            response = CommandOutput.class
+    )
+    @ApiResponses(@ApiResponse(code = 500, message = "Request failed"))
+    Response getHttpdConfig(@ApiParam(value = "The ID of the web server", required = true) @PathParam("webServerId") final Identifier<WebServer> aWebServerId);
 
     @GET
     @Path("/{wsName}/resources/name")
-    Response getResourceNames(@PathParam("wsName") final String wsName);
+    @ApiOperation(value = "Get all of the resource names for a web server",
+            response = String.class
+    )
+    Response getResourceNames(@ApiParam(value = "The name of the web server", required = true) @PathParam("wsName") final String wsName);
 
     /**
      * Get resource template content.
@@ -77,23 +122,34 @@ public interface WebServerServiceRest {
      */
     @GET
     @Path("/{wsName}/resources/template/{resourceTemplateName}")
-    Response getResourceTemplate(@PathParam("wsName") final String wsName,
-                                 @PathParam("resourceTemplateName") final String resourceTemplateName,
-                                 @QueryParam("tokensReplaced") final boolean tokensReplaced);
+    @ApiOperation(value = "Get a resource template for a web server",
+            response = String.class
+    )
+    Response getResourceTemplate(@ApiParam(value = "The name of the web server", required = true) @PathParam("wsName") final String wsName,
+                                 @ApiParam(value = "The name of the resource", required = true) @PathParam("resourceTemplateName") final String resourceTemplateName,
+                                 @ApiParam(value = "If true then return the generated template, else return the raw template", required = true) @QueryParam("tokensReplaced") final boolean tokensReplaced);
 
     @PUT
     @Path("/{wsName}/resources/template/{resourceTemplateName}")
     @Consumes(MediaType.TEXT_PLAIN)
-    Response updateResourceTemplate(@PathParam("wsName") final String wsName,
-                                    @PathParam("resourceTemplateName") final String resourceTemplateName,
-                                    final String content);
+    @ApiOperation(value = "Update a web server template",
+            response = String.class
+    )
+    @ApiResponses(@ApiResponse(code = 500, message = "Failed to update the template"))
+    Response updateResourceTemplate(@ApiParam(value = "The name of the web server", required = true) @PathParam("wsName") final String wsName,
+                                    @ApiParam(value = "The name of the resource", required = true) @PathParam("resourceTemplateName") final String resourceTemplateName,
+                                    @ApiParam(value = "The new content of the resource", required = true) final String content);
 
     @PUT
     @Path("/{webServerName}/resources/preview/{resourceTemplateName}")
     @Consumes(MediaType.TEXT_PLAIN)
-    Response previewResourceTemplate(@PathParam("webServerName") String webServerName,
-                                     @PathParam("resourceTemplateName") final String resourceTemplateName,
-                                     @MatrixParam("groupName") String groupName,
-                                     String template);
+    @ApiOperation(value = "Preview the generated content of a web server's resource template",
+            response = String.class
+    )
+    @ApiResponses(@ApiResponse(code = 500, message = "Error previewing template"))
+    Response previewResourceTemplate(@ApiParam(value = "The name of the web server", required = true) @PathParam("webServerName") String webServerName,
+                                     @ApiParam(value = "The name of the resource to preview", required = true) @PathParam("resourceTemplateName") final String resourceTemplateName,
+                                     @ApiParam(value = "The name of the web server's group", required = true) @MatrixParam("groupName") String groupName,
+                                     @ApiParam(value = "The content to be generated", required = true) String template);
 
 }

--- a/jwala-webservices/src/main/java/com/cerner/jwala/ws/rest/v1/service/webserver/WebServerServiceRest.java
+++ b/jwala-webservices/src/main/java/com/cerner/jwala/ws/rest/v1/service/webserver/WebServerServiceRest.java
@@ -35,7 +35,7 @@ public interface WebServerServiceRest {
 
     @POST
     @Consumes(MediaType.APPLICATION_JSON)
-    @ApiOperation(value = "Create a web server",
+    @ApiOperation(value = "Create a web server on Jwala database, The actual webserver instance on the server is created only after generate operation",
             response = WebServer.class
     )
     @ApiResponses(@ApiResponse(code = 500, message = "Web Server already exists"))
@@ -53,7 +53,7 @@ public interface WebServerServiceRest {
 
     @DELETE
     @Path("/{webserverId}")
-    @ApiOperation(value = "Delete a web server",
+    @ApiOperation(value = "Delete a web server with the boolean hardDelete, when set to true it will delete web server from services and Jwala database and when set to false it will only delete the web server from Jwala database",
             response = Response.class
     )
     Response deleteWebServer(@ApiParam(value = "The ID of the web server to be deleted", required = true) @PathParam("webserverId") final Identifier<WebServer> id,

--- a/jwala-webservices/src/main/java/com/cerner/jwala/ws/rest/v1/service/webserver/WebServerServiceRest.java
+++ b/jwala-webservices/src/main/java/com/cerner/jwala/ws/rest/v1/service/webserver/WebServerServiceRest.java
@@ -40,7 +40,7 @@ public interface WebServerServiceRest {
     )
     @ApiResponses(@ApiResponse(code = 500, message = "Web Server already exists"))
     Response createWebServer(@ApiParam(value = "The configuration info for the web server to be created", required = true) final JsonCreateWebServer aWebServerToCreate,
-                             @BeanParam final AuthenticatedUser aUser);
+                             @ApiParam(value = "The authentication details of user") @BeanParam final AuthenticatedUser aUser);
 
     @PUT
     @Consumes(MediaType.APPLICATION_JSON)
@@ -58,7 +58,7 @@ public interface WebServerServiceRest {
     )
     Response deleteWebServer(@ApiParam(value = "The ID of the web server to be deleted", required = true) @PathParam("webserverId") final Identifier<WebServer> id,
                              @ApiParam(value = "Deletes the web server and its service when set to true; only deletes the web server when false", required = true) @QueryParam("hardDelete") boolean hardDelete,
-                             @BeanParam final AuthenticatedUser user);
+                             @ApiParam(value = "The authentication details of user") @BeanParam final AuthenticatedUser user);
 
     @POST
     @Path("/{webServerId}/commands")
@@ -68,7 +68,7 @@ public interface WebServerServiceRest {
     @ApiResponses(@ApiResponse(code = 500, message = "Web Server operation unsuccessful"))
     Response controlWebServer(@ApiParam(value = "The ID of the web server", required = true) @PathParam("webServerId") final Identifier<WebServer> aWebServerId,
                               @ApiParam(value = "The control operation to execute", required = true) final JsonControlWebServer aWebServerToControl,
-                              @BeanParam final AuthenticatedUser aUser,
+                              @ApiParam(value = "The authentication details of user") @BeanParam final AuthenticatedUser aUser,
                               @ApiParam(value = "If set to true then block the thread until the control operation returns", required = true) @QueryParam("wait") final Boolean wait,
                               @ApiParam(value = "When 'wait=true' set a maximum time to block the thread", required = true) @QueryParam("timeout") final Long waitTimeout);
 
@@ -87,7 +87,7 @@ public interface WebServerServiceRest {
     )
     Response generateAndDeployConfig(@ApiParam(value = "The name of the web server associated with the resource", required = true) @PathParam("webServerName") final String webServerName,
                                      @ApiParam(value = "The name of the resource to be generated and deployed", required = true) @PathParam("fileName") String fileName,
-                                     @BeanParam final AuthenticatedUser aUser);
+                                     @ApiParam(value = "The authentication details of user") @BeanParam final AuthenticatedUser aUser);
 
     @PUT
     @Path("/{webServerName}/conf/deploy")


### PR DESCRIPTION
Use the swagger-gradle-plugin (https://github.com/gigaSproule/swagger-gradle-plugin) to generate the REST API documentation
- TODO
  - add swagger annotation to all existing REST APIs
  - change localhost to server name
  - determine toc/jwala context path
  - figure out how to hide the \@BeanParam authUser parameter from swagger (prevents GET calls from executing in swagger UI)

  