### PR TITLE
Delete linux service

### DIFF
--- a/jwala-integration-test/src/test/java/com/cerner/jwala/ui/selenium/steps/TearDownStep.java
+++ b/jwala-integration-test/src/test/java/com/cerner/jwala/ui/selenium/steps/TearDownStep.java
@@ -148,7 +148,7 @@ public class TearDownStep {
                     remoteCommandReturnInfo = jschService.runShellCommand(remoteSystemConnection, "sc delete " + serviceInfo.name, CONNECTION_TIMEOUT);
                     break;
                 case UNIX:
-                    remoteCommandReturnInfo = jschService.runShellCommand(remoteSystemConnection, "chkconfig --del " + serviceInfo.name, CONNECTION_TIMEOUT);
+                    remoteCommandReturnInfo = jschService.runShellCommand(remoteSystemConnection, "sudo chkconfig --del " + serviceInfo.name, CONNECTION_TIMEOUT);
                     remoteCommandReturnInfo = jschService.runShellCommand(remoteSystemConnection, "sudo rm /etc/init.d/" + serviceInfo.name, CONNECTION_TIMEOUT);
                     break;
                 default:

--- a/jwala-integration-test/src/test/java/com/cerner/jwala/ui/selenium/steps/TearDownStep.java
+++ b/jwala-integration-test/src/test/java/com/cerner/jwala/ui/selenium/steps/TearDownStep.java
@@ -1,8 +1,5 @@
 package com.cerner.jwala.ui.selenium.steps;
 
-import static com.cerner.jwala.common.domain.model.webserver.WebServerReachableState.*;
-import static com.cerner.jwala.common.domain.model.jvm.JvmState.*;
-
 import com.cerner.jwala.common.exec.RemoteSystemConnection;
 import com.cerner.jwala.common.jsch.JschService;
 import com.cerner.jwala.common.jsch.JschServiceException;
@@ -21,6 +18,11 @@ import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
+
+import static com.cerner.jwala.common.domain.model.jvm.JvmState.JVM_NEW;
+import static com.cerner.jwala.common.domain.model.jvm.JvmState.JVM_STARTED;
+import static com.cerner.jwala.common.domain.model.webserver.WebServerReachableState.WS_NEW;
+import static com.cerner.jwala.common.domain.model.webserver.WebServerReachableState.WS_REACHABLE;
 
 /**
  * Created by Jedd Cuison on 8/7/2017
@@ -146,6 +148,7 @@ public class TearDownStep {
                     remoteCommandReturnInfo = jschService.runShellCommand(remoteSystemConnection, "sc delete " + serviceInfo.name, CONNECTION_TIMEOUT);
                     break;
                 case UNIX:
+                    remoteCommandReturnInfo = jschService.runShellCommand(remoteSystemConnection, "chkconfig --del " + serviceInfo.name, CONNECTION_TIMEOUT);
                     remoteCommandReturnInfo = jschService.runShellCommand(remoteSystemConnection, "sudo rm /etc/init.d/" + serviceInfo.name, CONNECTION_TIMEOUT);
                     break;
                 default:

--- a/jwala-tomcat/src/main/resources/data/scripts/delete-service.sh
+++ b/jwala-tomcat/src/main/resources/data/scripts/delete-service.sh
@@ -22,7 +22,9 @@ fi
 
 if $linux; then
     if $linux; then
-        if [ test -e "/etc/init.d/$1" ]; then
+        if [ -e "/etc/init.d/$1" ]; then
+          echo chkconfig --del $1
+          /usr/bin/sudo /sbin/chkconfig --del $1
           echo delete /etc/init.d/$1
           /usr/bin/sudo rm /etc/init.d/$1
         fi

--- a/jwala-tomcat/src/main/resources/data/scripts/delete-service.sh
+++ b/jwala-tomcat/src/main/resources/data/scripts/delete-service.sh
@@ -21,12 +21,10 @@ if $cygwin; then
 fi
 
 if $linux; then
-    if $linux; then
-        if [ -e "/etc/init.d/$1" ]; then
-          echo chkconfig --del $1
-          /usr/bin/sudo /sbin/chkconfig --del $1
-          echo delete /etc/init.d/$1
-          /usr/bin/sudo rm /etc/init.d/$1
-        fi
+    if [ -e "/etc/init.d/$1" ]; then
+        echo chkconfig --del $1
+        /usr/bin/sudo /sbin/chkconfig --del $1
+        echo delete /etc/init.d/$1
+        /usr/bin/sudo rm /etc/init.d/$1
     fi
 fi


### PR DESCRIPTION
The fix requires 2 changes:
- remove the 'test' keyword when checking the existing of the init.d service script
- add a call to clean up the run level setting for the service (chkconfig)

Also added the line to clean up the run level setting in the Selenium tear down step.