### PR TITLE
Removed deprecated states for components that implement Lifecycle in JvmStateReceiverAdapter

### DIFF
--- a/jwala-services/src/main/java/com/cerner/jwala/service/jvm/state/JvmStateReceiverAdapter.java
+++ b/jwala-services/src/main/java/com/cerner/jwala/service/jvm/state/JvmStateReceiverAdapter.java
@@ -42,8 +42,6 @@ public class JvmStateReceiverAdapter extends ReceiverAdapter {
         LIFECYCLE_JWALA_JVM_STATE_REF_MAP.put(LifecycleState.FAILED, JvmState.JVM_FAILED);
         LIFECYCLE_JWALA_JVM_STATE_REF_MAP.put(LifecycleState.INITIALIZED, JvmState.JVM_INITIALIZED);
         LIFECYCLE_JWALA_JVM_STATE_REF_MAP.put(LifecycleState.INITIALIZING, JvmState.JVM_INITIALIZED);
-        LIFECYCLE_JWALA_JVM_STATE_REF_MAP.put(LifecycleState.MUST_DESTROY, JvmState.JVM_STOPPING);
-        LIFECYCLE_JWALA_JVM_STATE_REF_MAP.put(LifecycleState.MUST_STOP, JvmState.JVM_STOPPING);
         LIFECYCLE_JWALA_JVM_STATE_REF_MAP.put(LifecycleState.NEW, JvmState.JVM_INITIALIZED);
         LIFECYCLE_JWALA_JVM_STATE_REF_MAP.put(LifecycleState.STARTED, JvmState.JVM_STARTED);
         LIFECYCLE_JWALA_JVM_STATE_REF_MAP.put(LifecycleState.STARTING, JvmState.JVM_STARTING);


### PR DESCRIPTION
The Life cycle states 
MUST_DESTROY and MUST_STOP have been deprecated in Tomcat 9. Hence, removed the declarations.
So, that Jwala works with Tomcat 9.0.14. 