### PR TITLE
Fix postman test

### DIFF
--- a/jwala-integration-test/src/test/postman/jwala-collection.postman_collection.json
+++ b/jwala-integration-test/src/test/postman/jwala-collection.postman_collection.json
@@ -5603,6 +5603,17 @@
 				},
 				{
 					"name": "error: generate and deploy webserver when started exception",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"type": "text/javascript",
+								"exec": [
+									"setTimeout(function(){}, 5000);"
+								]
+							}
+						}
+					],
 					"request": {
 						"url": "{{url}}/v1.0/webservers/{{WebserverName}}/conf/deploy",
 						"method": "PUT",

--- a/jwala-integration-test/src/test/postman/jwala-collection.postman_collection.json
+++ b/jwala-integration-test/src/test/postman/jwala-collection.postman_collection.json
@@ -5616,39 +5616,6 @@
 					"response": []
 				},
 				{
-					"name": "stop webserver",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"type": "text/javascript",
-								"exec": [
-									"setTimeout(function(){}, 5000);",
-									"tests[\"Status code is 200\"] = responseCode.code === 200;",
-									""
-								]
-							}
-						}
-					],
-					"request": {
-						"url": "{{url}}/v1.0/webservers/{{WebserverId}}/commands",
-						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"value": "application/json",
-								"description": ""
-							}
-						],
-						"body": {
-							"mode": "raw",
-							"raw": "{\"controlOperation\":\"stop\"}"
-						},
-						"description": ""
-					},
-					"response": []
-				},
-				{
 					"name": "stop jvm",
 					"event": [
 						{

--- a/jwala-integration-test/src/test/postman/jwala-collection.postman_collection.json
+++ b/jwala-integration-test/src/test/postman/jwala-collection.postman_collection.json
@@ -5616,6 +5616,39 @@
 					"response": []
 				},
 				{
+					"name": "stop webserver",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"type": "text/javascript",
+								"exec": [
+									"setTimeout(function(){}, 5000);",
+									"tests[\"Status code is 200\"] = responseCode.code === 200;",
+									""
+								]
+							}
+						}
+					],
+					"request": {
+						"url": "{{url}}/v1.0/webservers/{{WebserverId}}/commands",
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json",
+								"description": ""
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\"controlOperation\":\"stop\"}"
+						},
+						"description": ""
+					},
+					"response": []
+				},
+				{
 					"name": "stop jvm",
 					"event": [
 						{


### PR DESCRIPTION
The postman tests were failing because the web server was sending back an unknown status in response to a stop command.

There were 2 solutions that worked:
1. Remove the test
2. Add more delay between the tests

In looking at the series of steps leading up to the sending of the stop command, I couldn't really understand what the tests were trying to accomplish - hence Option 1. But, I assumed the test was exercising some sort of edge case and I didn't want to lose the code coverage.

Option 2 is slightly better in that we don't lose the code coverage, but now we're dealing with a fragile test. Could this break again in the future? Maybe. If so, then we really need to consider doing a proper clean up.