### PR TITLE
Fix the postman tests by starting the group first

### DIFF
--- a/jwala-integration-test/src/test/postman/jwala-collection.postman_collection.json
+++ b/jwala-integration-test/src/test/postman/jwala-collection.postman_collection.json
@@ -5616,39 +5616,6 @@
 					"response": []
 				},
 				{
-					"name": "stop webserver",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"type": "text/javascript",
-								"exec": [
-									"setTimeout(function(){}, 5000);",
-									"tests[\"Status code is 200\"] = responseCode.code === 200;",
-									""
-								]
-							}
-						}
-					],
-					"request": {
-						"url": "{{url}}/v1.0/webservers/{{WebserverId}}/commands",
-						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"value": "application/json",
-								"description": ""
-							}
-						],
-						"body": {
-							"mode": "raw",
-							"raw": "{\"controlOperation\":\"stop\"}"
-						},
-						"description": ""
-					},
-					"response": []
-				},
-				{
 					"name": "stop jvm",
 					"event": [
 						{

--- a/jwala-integration-test/src/test/postman/jwala-collection.postman_collection.json
+++ b/jwala-integration-test/src/test/postman/jwala-collection.postman_collection.json
@@ -5616,6 +5616,39 @@
 					"response": []
 				},
 				{
+					"name": "stop webserver",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"type": "text/javascript",
+								"exec": [
+									"setTimeout(function(){}, 5000);",
+									"tests[\"Status code is 200\"] = responseCode.code === 200;",
+									""
+								]
+							}
+						}
+					],
+					"request": {
+						"url": "{{url}}/v1.0/webservers/{{WebserverId}}/commands",
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json",
+								"description": ""
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\"controlOperation\":\"stop\"}"
+						},
+						"description": ""
+					},
+					"response": []
+				},
+				{
 					"name": "stop jvm",
 					"event": [
 						{

--- a/jwala-integration-test/src/test/postman/jwala-collection.postman_collection.json
+++ b/jwala-integration-test/src/test/postman/jwala-collection.postman_collection.json
@@ -5603,17 +5603,6 @@
 				},
 				{
 					"name": "error: generate and deploy webserver when started exception",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"type": "text/javascript",
-								"exec": [
-									"setTimeout(function(){}, 5000);"
-								]
-							}
-						}
-					],
 					"request": {
 						"url": "{{url}}/v1.0/webservers/{{WebserverName}}/conf/deploy",
 						"method": "PUT",

--- a/jwala-integration-test/src/test/postman/jwala-collection.postman_collection.json
+++ b/jwala-integration-test/src/test/postman/jwala-collection.postman_collection.json
@@ -5553,10 +5553,10 @@
 		},
 		{
 			"name": "p) control operation stop",
-			"description": "",
+			"description": "set up the tests by first starting the group",
 			"item": [
 				{
-					"name": "stop group",
+					"name": "start group",
 					"event": [
 						{
 							"listen": "test",
@@ -5581,7 +5581,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\"controlOperation\":\"stop\"}"
+							"raw": "{\"controlOperation\":\"start\"}"
 						},
 						"description": ""
 					},
@@ -5694,14 +5694,14 @@
 					],
 					"request": {
 						"url": {
-							"raw": "{{url}}/v1.0/webservers/{{WebserverId}}/commands?wait=TRUE",
+							"raw": "{{url}}/v1.0/webservers/{{WebserverId2}}/commands?wait=TRUE",
 							"host": [
 								"{{url}}"
 							],
 							"path": [
 								"v1.0",
 								"webservers",
-								"{{WebserverId}}",
+								"{{WebserverId2}}",
 								"commands"
 							],
 							"query": [


### PR DESCRIPTION
First, revert the changes from the last commit.

Then, start the test group before running the stop tests. 

I'm not sure if this was a mistake from the initial creation of the tests, but at least now the sequence of start and stops make sense. How did this ever work before???