### PR TITLE
fix for thread dump using OpenJDK

### DIFF
--- a/jwala-webapp/src/main/webapp/resources/js/react/group-operations/GroupOperationsDataTable.js
+++ b/jwala-webapp/src/main/webapp/resources/js/react/group-operations/GroupOperationsDataTable.js
@@ -751,7 +751,7 @@ var GroupOperationsDataTable = React.createClass({
                     var indexOfMessage = msg.indexOf('Creating');
                     var endOfMessage = msg.length
                     var message = msg.substring(indexOfMessage,endOfMessage);
-                    if (message.trim() === "" || msg.indexOf('Full thread dump Java') === -1) {
+                    if (message.trim() === "" || msg.indexOf('Full thread dump') === -1) {
                         msg = "Oops! Something went wrong! The JVM might not have been started.";
                         $.errorAlert(msg, "Thread Dump", false);
                     } else {


### PR DESCRIPTION
Update the conditional string in the UI to only test for a partial string: "Full thread dump". This matches the string used in the threadDump.sh script.

For Oracle JDK the response message is:
Full thread dump Java HotSpot(TM) 64-Bit Server VM (25.92-b14 mixed mode)

For OpenJDK the response message is:
Full thread dump OpenJDK 64-Bit Server VM (25.192-b12 mixed mode)